### PR TITLE
docs: edit Archway about doc for typos and rewrite

### DIFF
--- a/docs/overview/about.md
+++ b/docs/overview/about.md
@@ -8,17 +8,17 @@ description: A self-sovereign blockchain network that allows developers to expre
 
 Archway is an incentivized smart contract platform that rewards developers — ushering in next gen dApps.
 
-The protocol gives developers the tools to easily build and launch scalable cross-chain dApps, and get rewarded for the value they contribute to the network.
+The protocol gives developers the tools to quickly build and launch scalable cross-chain dApps and get rewarded for the value the dApps contribute to the network.
 
 ## The Archway Mission
 
 The overarching goal of Archway is to foster an array of diverse and sustainable applications by empowering and rewarding developers that build on the network with baked in incentives and rewards.
 
-The internet helped to democratize access to information, but it hasn’t fully democratized access to capital and value. Entrepreneurs and developers around the world lack access to the same opportunities as their counterparts in more developed nations.
+The internet helped democratize access to information, but it hasn't fully democratized access to capital and value. Entrepreneurs and developers worldwide lack access to the same opportunities as their counterparts in more developed nations.
 
 Archway aims to level the playing field. Built into the protocol itself, Archway rewards developers based on the value and impact of their dApp, rather than their close association or connections to capital. 
 
-Unlike existing Web 2.0 platforms or early versions of Web3 layer 1s, where tokens are mostly concentrated in the hands of the first few early participants, Archway is designed to be shared across all contributors and stakeholders. The entrepreneurs and developers who are building on Archway get a true stake in the growth and governance of the protocol itself.
+Unlike existing Web 2.0 platforms or early versions of Web 3 Layer-1s, where tokens are mostly concentrated in the hands of the first few early participants, Archway is designed to be shared across all contributors and stakeholders. The entrepreneurs and developers who are building on Archway get a true stake in the growth and governance of the protocol itself.
 
 
 <!-- Architecture -->
@@ -27,28 +27,31 @@ Unlike existing Web 2.0 platforms or early versions of Web3 layer 1s, where toke
 
 The network starts with a vanilla Proof-of-Stake (PoS) network, with modified Minting, CosmWasm, Distribution, Staking, Group, and Governance Cosmos modules that manage the Archway inflation and rewards system. 
 
-Archway creates a Cosmos SDK-based chain with support for WASM smart contract execution that rewards developers for the usage of said smart contracts deployed.
+Archway creates a Cosmos SDK-based chain with support for WASM smart contract execution that rewards developers for using the deployed smart contracts.
 
 Desired functionalities to achieve above objective:
+
 - [Fee reward to the developers](#economic-overview)
 - [Gas rebate to end users](#gas-rebates)
 - [Smart contract premium fee](#smart-contract-fees)
 - [Inflation rewards](#inflation)
 
 ### Smart Contracts
+
 The Archway protocol uses CosmWasm, WebAssembly (Wasm), and Rust. Over 40 high-level programming languages support Wasm, including C and C++, Python, Go, Rust, Java, and PHP.
 
-#### Difference Between Smart Contracts and Cosmos Zones
-While the ethos of Cosmos is to create your own self-sovereign chain, in many cases, it makes sense for a project to first deploy as a dApp. There is a lot of overhead in launching and maintaining a standalone chain. While the Cosmos SDK simplifies much of the technical effort, a developer still needs to attract and sufficiently incentivize a strong community of validators to run the network, which can be a daunting endeavor for early projects.
+#### Difference Between Smart Contracts and Cosmos Chains
+
+While the ethos of Cosmos is for developers to create their own self-sovereign chains, in many cases, it makes sense for a project to first deploy as a dApp. There is a lot of overhead in launching and maintaining a standalone chain. While the Cosmos SDK simplifies much of the technical effort, a developer still needs to attract and sufficiently incentivize a strong community of validators to run the network. These efforts and coordination can be a daunting endeavor for early projects.
 
 Consider the following tradeoffs between building your core logic as a smart contract versus building your logic as an independent Cosmos blockchain.
 
-|                          | Cosmos Chain | Smart Contract|
+|       Goal               | Cosmos Chain | Smart Contract|
 |      :----:              |    :----:    |    :----:     |
 |Speed of development      | -            | +             | 
 |Ease of development       | -            | +             | 
 |Complexity of logic       | +            | +             | 
-|Mantenance overhead       | -            | +             | 
+|Maintenance overhead      | -            | +             | 
 |Level of customization    | +            | -             | 
 |Strict resource control   | -            | +             | 
 |Native chain features     | +            | -             | 
@@ -57,9 +60,9 @@ Consider the following tradeoffs between building your core logic as a smart con
 
 <!-- Architecture : Modules -->
 
-## Module specifications
+## Module Specifications
 
-Here you'll find some information about Archway specfic modules that extend the functionality of the Cosmos SDK
+These Archway-specific modules extend the functionality of the Cosmos SDK.
 
 ### Gas Tracking
 
@@ -67,12 +70,14 @@ To achieve the Archway architecture [desired properties](#the-archway-mission), 
 
 - Wrap the [CosmWasm](./glossary.md#cosmwasm) VM with an Archway GasMeter to allow interception and tracking of information passed by the VM.
 - During BeginBlock, the recorded information is brought to memory and processed to determine rewards for each of the contracts executed in the last block. 
-- Developers can choose to take the rewards, or give the gas rebate to end users to subsidize transaction cots. To enable that choice, utilize a proxy wrapper that expects that during the instantiate call the developer can specify configuration parameters that are related to the gas reward as well as the instantiation request body. This body is consumed by the wrapper and the contract is sent only instantiation requests which means the contract interface does not need to be changed.
-- Developer reward payout can happen on demand or automatically. But, the disadvantage of on demand reward is an inferior user experience and results in more transactions just to transfer the rewards. Alternatively when the reward is allocated in BeginBlock, it is automatically transferred to the designated reward address when it crosses a certain threshold. 
+- Developers can choose to take the rewards or give the gas rebate to end users to subsidize transaction costs. To enable that choice, use a proxy wrapper. The wrapper expects the developer to specify configuration parameters during the instantiate call. The parameters are related to the gas reward and the instantiation request body. This body is consumed by the wrapper and the contract is sent only instantiation requests which means the contract interface does not need to be changed.
+- Developer reward payout can happen on demand or automatically at BeginBlock. 
+    - The disadvantage of on-demand reward is an inferior user experience and results in more transactions just to transfer the rewards. 
+    - The advantage of on-demand reward is that the reward is automatically transferred to the designated reward address when it crosses a certain threshold.  
 
 #### Drawbacks
 
-The Cosmos SDK does not support post-transaction processing. Archway takes into account GasLimit instead of actual gas consumption by the transaction. The good news is that the Cosmos SDK mght have this functionality in the future.
+The Cosmos SDK does not support post-transaction processing. Archway takes into account GasLimit instead of actual gas consumption by the transaction. The good news is that the Cosmos SDK could potentially have post-transaction functionality in the future.
 
 
 <!-- Economics -->
@@ -87,7 +92,7 @@ Archway seeks to provide three potential funding sources for dApps:
 - Share of inflationary rewards
 - Smart contract fees (optional)
 
-Archway allows each dApp developer and their community to configure how the rewards are managed and distributed. When a contract is instantiated, the dApp creator specifies an `owner` address where all fees and rewards are automatically deposited. This target address can be their own, a multisig, or controlled by a separate custom contract. Ownership can then be transferred to a new address as needed, only requiring the signature of the previous owner. 
+Archway allows each dApp developer and their community to configure how the rewards are managed and distributed. When a contract is instantiated, the dApp creator specifies an `owner` address where all fees and rewards are automatically deposited. This target address can be the creator's address, a multisig, or an address that is controlled by a separate custom contract. Ownership can then be transferred to a new address as needed. Ownership transfer requires only the signature of the previous owner. 
 
 <!-- Economics : Gas Rebates -->
 
@@ -95,13 +100,13 @@ Archway allows each dApp developer and their community to configure how the rewa
 
 Unlike existing smart contract platforms, Archway does not burn gas fees or distribute them entirely to the validators or miners. Instead, the collected gas fees are split between dApp developers and validators.
 
-At network launch, gas fees will be divided evenly with 50% going to dApp developers and 50% to validators. The network provides configurable parameters that can be adjusted over time to determine the optimal gas rebate distribution between validators and dApps.
+At network launch, gas fees are divided evenly with 50% going to dApp developers and 50% to validators. The network provides configurable parameters that can be adjusted over time to determine the optimal gas rebate distribution between validators and dApps.
 
-From the dApp developer's perspective, a contract receives a 50% rebate on all gas paid. From the validator's perspective, foregoing a portion of rewards in the near-term effectively drives transaction volumes, fees, and value of the underlying network in the future.
+From the dApp developer perspective, a contract receives a 50% rebate on all gas paid. From the validator perspective, deferring a portion of rewards in the near term effectively drives transaction volumes, fees, and increases the value of the underlying network in the future.
 
-It would not be profitable for an attacker to spam transactions on the network as gas rebates recoup only part of the fees paid (50%). As an additional safeguard against potential abuse, uploading new contracts requires higher gas fees than normal transactions to prevent the deployment of spam contracts, but sufficiently low to allow smaller projects to upload contracts.
+It would not be profitable for an attacker to spam transactions on the network as gas rebates recoup only part of the fees paid (50%). As an additional safeguard against potential abuse and to prevent the deployment of spam contracts, gas fees are higher for uploading new contracts than for routine transactions. Gas fees are still sufficiently low to allow smaller projects to upload contracts.
 
-Gas fee rebates are automatically paid out by the network on a per-block basis
+Gas fee rebates are automatically paid out by the network on a per-block basis.
 
 <!-- Economics : Inflation -->
 
@@ -109,13 +114,13 @@ Gas fee rebates are automatically paid out by the network on a per-block basis
 
 The overall inflation rate on the Archway network follows the model of the [mint module](https://github.com/gavinly/CosmosParametersWiki/blob/master/Mint.md) in the Cosmos Hub, with total token supply increasing between 7% and 20% annually, depending on the ratio of tokens that are actively staked on the network.
 
-The Archway protocol then shares a portion of these total inflation rewards directly with dApps. At genesis, 25% will go to dApp developers and 75% will go to validators. For example, if the network sees total annual inflation of 8%, then 2% would go to dApps and 6% would go to validators. These distribution values are configurable parameters that can be adjusted by the Archway community through network governance.
+The Archway protocol then shares a portion of these total inflation rewards directly with dApps. At genesis, 25% of inflation rewards go to dApp developers and 75% go to validators. For example, if the network sees total annual inflation of 8%, then 2% goes to dApps and 6% goes to validators. These distribution values are configurable parameters that can be adjusted by the Archway community through network governance.
 
 The dApp rewards pool (2% in the previous example) is then proportionally distributed based on the relative amount of gas fees that each dApp generates within a given epoch. For example, a dApp that is responsible for 10% of gas consumption is awarded 10% of the available pool.
 
-To mitigate potential Sybil attacks and ensure spamming transactions is not profitable, each dApp has a max inflation rewards cap. At network launch, there is a hard cap based on the total gas fees paid per dApp. A contract deployed to Archway cannot earn rewards greater than the total gas it generates within an epoch. Implementation of a dynamic rewards cap is being actively researched and can be updated through future governance. Transitioning to a floating cap will provide more flexible distribution and further incentivize developers to continuously improve their dApps.
+To mitigate potential Sybil attacks and ensure spamming transactions is not profitable, each dApp has a max inflation rewards cap. At network launch, there is a hard cap based on the total gas fees paid per dApp. A contract deployed to Archway cannot earn rewards greater than the total gas it generates within an epoch. Implementation of a dynamic rewards cap is being actively researched and can be updated through future governance. Transitioning to a floating cap provides more flexible distribution and further incentivizes developers to continuously improve their dApps.
 
-Any surplus in rewards will be contributed to the Archway community pool where the funds are managed through governance.
+Any surplus in rewards is contributed to the Archway community pool where the funds are managed through governance.
 
 Inflationary rewards are paid out by the network on a per-block basis.
 
@@ -129,18 +134,18 @@ dApps can choose to allocate the rewards they accrue in whatever way is most ben
 
 #### Governance Rewards
 
-A recent trend has dApps issuing governance tokens to incentivize and bootstrap early communities. This has proved to be very successful in a number of cases,  despite the dApp not having any clear mechanism for value capture for fees or revenues. Some of these tokens merely grant voting rights, but have nevertheless been the subject of intense growth due to speculation of future utility of the dApp or potential rights of governance token holders to cash flows. 
+A recent trend has dApps issuing governance tokens to incentivize and bootstrap early communities. This token distribution has proved to be very successful in a number of cases,  despite the dApp not having any clear mechanism for value capture for fees or revenues. Some of these tokens merely grant voting rights, but have still been the subject of intense growth due to speculation of future utility of the dApp or potential rights to cash flows by governance token holders. 
 
 In the Archway model, dApp developers can redistribute their share of network rewards directly to their governance token holders, subject to local securities laws. The Archway model turns standard governance tokens into productive, yield-generating assets. 
 
-While individual dApps on other networks, such as SushiSwap have implemented similar functionality, the Archway protocol makes it possible to implement and manage governance rewards at the protocol level itself. A developer can opt in and automatically redirect funds earned by the dApp, including gas rebates, inflation rewards, and even smart contract fees, straight to governance token holders. 
+While individual dApps on other networks, such as SushiSwap, have implemented similar functionality, the Archway protocol makes it possible to implement and manage governance rewards at the protocol level itself. A developer can opt-in and automatically redirect to governance token holders the funds earned by the dApp, including gas rebates, inflation rewards, and even smart contract fees. 
 
 
 #### Support the Core Development Team
 
 Rewards offered by Archway could help developers bootstrap new projects without having to dedicate excessive time and focus to fundraising. The process of raising early capital can be difficult for developers of individual dApps. 
 
-Development teams often resort to private insider sales that skew early token distribution or are forced to rely on foundation grant programs. Rather than prioritizing the best technology and ecosystem for their dApp, they often choose based on available grants and get locked into a single platform.
+Development teams often resort to private insider sales that skew early token distribution or are forced to rely on foundation grant programs. Rather than prioritizing the best technology and ecosystem for their dApp, developers often choose a tech stack that is based on available grants and are then locked into a single platform.
 
 Even after a dApp is launched, developers continuing to support the dApp codebase may find it difficult to cover ongoing development costs as the blockchain industry is still nascent and winning business models have yet to materialize.
 
@@ -151,7 +156,7 @@ The model introduced by Archway can counter some of these early financial pressu
 
 Gas payments remain one of the critical barriers to delivering a simple, intuitive user experience for dApps. Archway supports gasless transactions through the use of pool accounts. A dApp can pull funds from a common pool to sponsor gas payments and completely abstract away that complexity and friction for their end users.
 
-To fund the balance of the pool account, a developer can use the fees and rewards generated by the dApp itself. In effect, the dApp gets a 50% discount on each transaction from gas rebates along with inflation rewards and contract fees that are potentially available as a bonus. 
+To fund the pool account balance, a developer can use the fees and rewards generated by the dApp itself. In effect, the dApp gets a 50% discount on each transaction from gas rebates along with inflation rewards and contract fees that are potentially available as a bonus. 
 
 By recycling these funds, dApps have the option to dramatically reduce or eliminate the gas burden for end users, leading to a smoother onboarding process and stronger retention over time.
 
@@ -160,7 +165,7 @@ By recycling these funds, dApps have the option to dramatically reduce or elimin
 
 Rewards generated by a dApp can be contributed to a community-owned DAO that is focused on coordinating and funding critical work for its ecosystem. These rewards can be continuously deposited to the DAO treasury that allows members to collectively manage and deploy the assets based on specific needs of the project.
 
-This DAO could then vote to fund core development teams, sponsor events and hackathons, commission code audits, open bug bounties, launch education programs, subsidize third-party integrations, and so on. Anything and everything that could potentially benefit and impact the ecosystem.
+This DAO could then vote to fund core development teams, sponsor events and hackathons, commission code audits, open bug bounties, launch education programs, subsidize third-party integrations, and so on. DAO funding could be available to anything and everything that could potentially benefit and impact the ecosystem.
 
 The DAO itself can exist and operate as a set of smart contracts on top of Archway, so the entire process is automated and transparent throughout initial rewards collection, voting, grants distribution, and so on.
 
@@ -168,7 +173,7 @@ Giving members collective control over a recurring funding source helps actively
 
 #### Boost Liquidity Mining Programs
 
-DeFi projects could use the funds earned from Archway to boost liquidity mining rewards, a vital strategy for attracting new users and encouraging active participation.   
+DeFi projects could use the funds earned from Archway to boost liquidity mining rewards, fulfilling a vital strategy for attracting new users and encouraging active participation.   
 
 For instance, a decentralized exchange (DEX) can be designed to distribute rewards on top of the fees already paid to their liquidity providers (LPs), while a lending platform can allow users to earn supplemental rewards for depositing and borrowing assets.
 
@@ -178,7 +183,7 @@ Although similar matching and subsidy programs have been run elsewhere as tempor
 
 On networks such as Ethereum, DEX users incur two sets of fees: a network fee and a swap fee. The network fee incentivizes miners to operate nodes and the swap fee incentivizes liquidity providers (LPs) to provide liquidity to the DEX.
 
-By deploying to Archway, DEXs could be constructed to effectively eliminate one of these fees. Instead, the DEX protocol could redistribute the earned gas rebates back to the LPs for providing liquidity to dramatically lower total transaction costs on automatic swaps and improve the user experience.
+By deploying to Archway, DEXs could be constructed to effectively eliminate one of the network or swap fees. Instead, the DEX protocol could redistribute the earned gas rebates back to the LPs for providing liquidity to dramatically lower total transaction costs on automatic swaps and improve the user experience.
 
 <!-- Economics : Fees -->
 
@@ -200,4 +205,4 @@ Since most dApps are composed of smaller, more modular pieces of code and layers
 
 Gvernance is the process by which Archway network participants and token holders can influence the future direction of the protocol through proposals and on-chain voting.
 
-In addition to fees and staking, Archway’s native token is used for governance. This helps maintain and support Archway’s decentralized community while ensuring fair and transparent participation. All holders of the native token can propose changes to the Archway protocol and vote on active proposals. Proposals that reach a consensus threshold are adopted, whether a specific feature or even changing the governance system itself.
+In addition to fees and staking, Archway’s native token is used for governance. This governance model helps maintain and support Archway’s decentralized community while ensuring fair and transparent participation. All holders of the native token can propose changes to the Archway protocol and vote on active proposals. Proposals that reach a consensus threshold are adopted, whether a specific feature or even changing the governance system itself.


### PR DESCRIPTION
Spied a few typos so I conducted a thorough edit and am suggesting a few rewrites for clarity

Guidance
- developer (not "we")
- omit the naked "it" and repeat the subject 

stay awesome, team! This overview is splendid