### PR TITLE
more spelling check

### DIFF
--- a/docs/create/advanced/debug.md
+++ b/docs/create/advanced/debug.md
@@ -24,7 +24,7 @@ DEBUG=* archway deploy --args '{ "name": "debugger", "symbol": "dbg!", "minter":
 
 ## Debug failing transactions
 
-If your transaction is failing use the `cargo schema` command to regenerate schema requirements for your project. The generated files will explain exactly what keys, types and values are permissible for entrypoints of the contract.
+If your transaction is failing use the `cargo schema` command to regenerate schema requirements for your project. The generated files will explain exactly what keys, types and values are permissible for entry points of the contract.
 
 Example:
 

--- a/docs/create/getting-started/basics.md
+++ b/docs/create/getting-started/basics.md
@@ -102,7 +102,7 @@ Without `--dry-run` enabled, `deploy` progresses through a series of tasks, the 
 5. **STORE DEPLOYMENT LOG**
 
 :::tip
-**Note:** The flags and options below allow you to surpress prompts, skip steps or resume a deployment. This can be helpful in the case of failing deployments.
+**Note:** The flags and options below allow you to suppress prompts, skip steps or resume a deployment. This can be helpful in the case of failing deployments.
 :::
 
 ```bash
@@ -119,7 +119,7 @@ archway deploy [options]
 | --no-build             | `archway deploy --no-build` | Do not build the project before deploying; it will fail if the wasm file is not built |
 | --no-verify            | `archway deploy --no-verify` | Do not verify the wasm file uploaded on-chain matches your local version |
 | --no-confirm           | `archway deploy --no-confirm` | Skip tx broadcasting prompt confirmation |
-| -d, --dry-run           | `archway deploy -d`        | Test deployability by building cargo wasm release binary       |
+| -d, --dry-run           | `archway deploy -d`        | Test deploy-ability by building cargo wasm release binary       |
 | -k, --docker           | `archway deploy -k`         | Use the docker version of `archwayd`                           |
 | -h, --help             | `archway deploy -h`         | Display help for deploy command                                |
 
@@ -229,7 +229,7 @@ archway query <module> [type] [options]
 
 | Option                 | Example                     | Description                                          |
 | ---------------------- | --------------------------- | ---------------------------------------------------- |
-| *-a, --args [string]   | `archway query contract-state smart --args '{"entrypoint_name": {}}'` | JSON encoded arguments for query. Calls a contract's `query` entrypoint. |
+| *-a, --args [string]   | `archway query contract-state smart --args '{"entrypoint_name": {}}'` | JSON encoded arguments for query. Calls a contract's `query` entry point. |
 | -k, --docker           | `archway query contract-state smart -k` | Use the docker version of `archwayd` |
 | -f, --flags [string]   | `archway query contract-state smart --args '{"entrypoint_name": {}}' -f '--height 361880'` | Send additional flags to `archwayd` by wrapping in a string; e.g. "--height 492520 --limit 10" |
 | -h, --help             | `archway query -h`          | Display help for query command                       |

--- a/docs/create/getting-started/install.md
+++ b/docs/create/getting-started/install.md
@@ -16,7 +16,7 @@ Make sure you've installed and configured a few dependencies.
 - [Archwayd](https://github.com/archway-network/archway/tree/main/cmd/archwayd "Install Archway Daemon")
 - [Docker](https://docs.docker.com/get-docker "Install Docker") (for Linux users, it's recommended to [run the Docker daemon in Rootless Mode](https://docs.docker.com/engine/security/rootless/))
 - [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm "Install Node.js and NPM")
-- [Archway Developer CLI](https://github.com/archway-network/archway-cli "Install develolper CLI")
+- [Archway Developer CLI](https://github.com/archway-network/archway-cli "Install developer CLI")
 
 ## Rustc
 
@@ -106,7 +106,7 @@ For installing `node.js` and `npm`, see instructions for your operating system a
 :::info
 `@archwayhq/cli` requires Node.js version 14 or higher, but some older versions in the `beta` release track required Node.js version 17. You can check which version you have installed using the command `archway --version`.
 
-[See all availble versions of @archwayhq/cli](https://www.npmjs.com/package/@archwayhq/cli?activeTab=versions)
+[See all available versions of @archwayhq/cli](https://www.npmjs.com/package/@archwayhq/cli?activeTab=versions)
 :::
 
 ## Archway Developer CLI

--- a/docs/create/getting-started/setup.md
+++ b/docs/create/getting-started/setup.md
@@ -129,5 +129,5 @@ Migrate to another network (Y/N default: N)?: n
 Ok!
 ```
 :::note
-If you migrate between networks by answering `y` or `yes` and following the additional migration questions, your previous deployments history and script customisations will remain in tact.
+If you migrate between networks by answering `y` or `yes` and following the additional migration questions, your previous deployments history and script customization will remain in tact.
 :::

--- a/docs/create/guides/nft-project/interact.md
+++ b/docs/create/guides/nft-project/interact.md
@@ -51,11 +51,11 @@ archway query contract-state smart --args '{"nft_info":{"token_id":"1"}}'
 # Show output here
 ```
 
-The behaviour of the `nft_info` entrypoint is defined [here](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) if you want to read the response model in detail.
+The behavior of the `nft_info` entry point is defined [here](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) if you want to read the response model in detail.
 
 ## Sending tokens
 
-To transfer a token, we have to send a message of the type `TransferNft`, which we achieve by sending a transaction to the [transfer_nft](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/execute.rs#L124-L139) entrypoint exposed by the contract. The params we send to the entrypoint are: the recipient address; and the `token_id` to be sent to the receiver.
+To transfer a token, we have to send a message of the type `TransferNft`, which we achieve by sending a transaction to the [transfer_nft](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/execute.rs#L124-L139) entry point exposed by the contract. The params we send to the entry point are: the recipient address; and the `token_id` to be sent to the receiver.
 
 In JSON format, our transaction arguments look like this:
 
@@ -74,7 +74,7 @@ Using the [Developer CLI](https://www.npmjs.com/package/@archwayhq/cli), we broa
 archway tx --args '{"transfer_nft":{"recipient":"archway1y00hm50lffnxt5m0kuy9afk83gyuye684zwcr5","token_id":"1"}}'
 ```
 
-Once the transaction confirms ownership of the token will be changed from the address declared as owner at minting (`archway1f395p0gg67mmfd5zcqvpnp9cxnu0hg6r9hfczq` in this guides's example), to the new receiver address (`archway1y00hm50lffnxt5m0kuy9afk83gyuye684zwcr5` in this guides's example). To verify that's the case, we can query the contract again to see who owns the `token_id` with the value of `'1'`.
+Once the transaction confirms ownership of the token will be changed from the address declared as owner at minting (`archway1f395p0gg67mmfd5zcqvpnp9cxnu0hg6r9hfczq` in this guide's example), to the new receiver address (`archway1y00hm50lffnxt5m0kuy9afk83gyuye684zwcr5` in this guide's example). To verify that's the case, we can query the contract again to see who owns the `token_id` with the value of `'1'`.
 
 ```bash
 archway query contract-state smart --args '{"nft_info":{"token_id":"1"}}'

--- a/docs/node/running-a-local-testnet.md
+++ b/docs/node/running-a-local-testnet.md
@@ -177,7 +177,7 @@ All we need is
 
 ## Join the network
 
-Since we are running it on our local machine, the Ip address is `0.0.0.0` which refers to `localhost` we can use either `localhost` or `127.0.0.1`. For me even `0.0.0.0` worked!
+Since we are running it on our local machine, the IP address is `0.0.0.0` which refers to `localhost` we can use either `localhost` or `127.0.0.1`. For me even `0.0.0.0` worked!
 
 Now let's run the following command to join the network:
 

--- a/docs/overview/glossary.md
+++ b/docs/overview/glossary.md
@@ -23,7 +23,7 @@ A framework that allows developers to write multi-chain smart contracts using an
 
 ## dApp
 
-An abbreviation of "decentralized application", dApps are applications built on Archway that combine smart contract functionality with a frontend web interface for users.
+An abbreviation of "decentralized application", dApps are applications built on Archway that combine smart contract functionality with a front-end web interface for users.
 
 <!-- E -->
 <!-- F -->

--- a/docs/participate/contribute.md
+++ b/docs/participate/contribute.md
@@ -50,7 +50,7 @@ Other useful resources:
 
 _Developer docs_ refers to documentation for smart contract and dApp developers. It's content to help users build and scale dApps on Archway network and contains information that is pertinent to:
 - Smart Contract development
-- Web and UI frontends that connect to Archway network
+- Web and UI front-ends that connect to Archway network
 - The [Archway developer CLI](https://www.npmjs.com/package/@archwayhq/cli)
 
 Developer docs are located in folder [/docs/create](https://github.com/archway-network/archway-docs/tree/main/docs/create) of the repository.

--- a/docs/participate/staking.md
+++ b/docs/participate/staking.md
@@ -14,7 +14,7 @@ Delegators are ARCH holders who cannot, or do not want to run a validator themse
 Now let's see how we can delegate some tokens to a validator.
 
 You can stake by:
-- [Runing a validator](/docs/validator/running-a-validator-node)
+- [Running a validator](/docs/validator/running-a-validator-node)
 - [Delegating](/docs/participate/staking#delegating)
 
 ## Delegating
@@ -153,7 +153,7 @@ Select a fee for the transaction and select the `Set Fee` button.
 
 ![](../assets/staking11.png)
 
-After a few moments, you ycan see the updates on our account.
+After a few moments, you can see the updates on our account.
 
 ![](../assets/staking12.png)
 

--- a/docs/validator/overview.md
+++ b/docs/validator/overview.md
@@ -16,7 +16,7 @@ If validators double sign, are frequently offline, or do not participate in gove
 
 Validators can set up a physical operation secured with restricted access. A good starting place, for example, would be co-locating in secure data centers.
 
-Validators are expected to equip their datacenter location with redundant power, connectivity, and storage backups. Plan to have several redundant networking boxes for fiber, firewall, and switching and also small servers with redundant hard drive and failover.  to start out, hardware can be on the low end of datacenter gear.
+Validators are expected to equip their data center location with redundant power, connectivity, and storage backups. Plan to have several redundant networking boxes for fiber, firewall, and switching and also small servers with redundant hard drive and failover.  to start out, hardware can be on the low end of data center gear.
 
 Archway network requirements are expected to be low initially. The current testnet requires minimal resources. Bandwidth, CPU, and memory requirements rise as the network grows. Large hard drives are recommended for storing years of blockchain history.
 


### PR DESCRIPTION
## Details

I ran `aspell` over the directory and found more typos. Are we good to merge the updates? [^1]

## Extension

Going forward, I suggest we check spelling on all public docs/code comments before publishing. Some snippets can be handly, like:

```bash
find . -type f -name "*.txt" -exec aspell check {} \;
```


[^1]: Aspell on my mac uses American convention for -ize/-ise.
