### PR TITLE
Fixes Issue #100. Adds missing install after binaryen build

### DIFF
--- a/docs/create/getting-started/install.mdx
+++ b/docs/create/getting-started/install.mdx
@@ -74,6 +74,7 @@ git submodule update
 After that you can build it with [CMake](https://cmake.org/)
 ```
 cmake . && make
+make install
 ```
 
 :::tip


### PR DESCRIPTION
Adds missing build instruction for Binaryen, as reported in Issue #100 