### PR TITLE
Guides->Basic NFT - adds React dApp example

### DIFF
--- a/docs/create/guides/nft-project/dapp.mdx
+++ b/docs/create/guides/nft-project/dapp.mdx
@@ -208,6 +208,6 @@ import TabItem from '@theme/TabItem';
     <a href="https://github.com/archway-network/dApp-examples/tree/main/vuejs/nft-basic" target="_blank">Vue Basic NFT</a>
   </TabItem>
   <TabItem value="react" label="React">
-    <p>React version coming soon...</p>
+    <a href="https://github.com/archway-network/dApp-examples/tree/main/react/nft-basic" target="_blank">React Basic NFT</a>
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Adds the React dApp example to the dApp guide