### PR TITLE
Updates dapp guides to use automatic gas estimation

### DIFF
--- a/docs/create/guides/my-first-dapp/dapp.mdx
+++ b/docs/create/guides/my-first-dapp/dapp.mdx
@@ -59,16 +59,20 @@ async function connectKeplrWallet() {
       await window.keplr.experimentalSuggestChain()
       await window.keplr.enable(ChainInfo.chainId);
       const offlineSigner = await window.getOfflineSigner(ChainInfo.chainId);
-      CosmWasmClient = await SigningCosmWasmClient.connectWithSigner(ChainInfo.rpc, offlineSigner);
+      gasPrice = GasPrice.fromString('0.002' + ChainInfo.currencies[0].coinMinimalDenom);
+      CosmWasmClient = await SigningCosmWasmClient.connectWithSigner(
+        ChainInfo.rpc, 
+        offlineSigner, 
+        { gasPrice: gasPrice }
+      );
      
       // This async waits for the user to authorize your dApp
       // it returns their account address only after permissions
       // to read that address are granted
       accounts = await this.offlineSigner.getAccounts();
  
+      // A less verbose reference to handle our queries
       queryHandler = CosmWasmClient.queryClient.wasm.queryContractSmart;
-      // Gas price
-      gasPrice = GasPrice.fromString('0.002uconst');
  
       console.log('Wallet connected', {
         offlineSigner: offlineSigner,
@@ -113,24 +117,32 @@ To broadcast transactions we call the `execute` function using our previous `Cos
 1. **userAddress** - the address broadcasting the transaction
 2. **ContractAddress** - the address of the contract the user is transacting with
 3. **entrypoint** - arguments to be executed which match an entrypoint in the contract
-4. **txFee** - transaction fees calculated by the `calculateFee` function from `@cosmjs/stargate`
+4. **Fee** - transaction fees can be manually calculated by the `calculateFee` function from `@cosmjs/stargate`, or "auto" to be automatically estimated.
+
+:::tip
+To use "auto" for fee estimation, the `SigningCosmWasmClient` constructor must be initialized with a `GasPrice` value. 
+Example:
+SigningCosmWasmClient.connectWithSigner(
+  ChainInfo.rpc, 
+  offlineSigner, 
+  { gasPrice: "0.002uconst" }
+);
+:::
 
 We convert the case of entrypoint arguments to lowercase and snake case again, so `ExecuteMsg::Increment {}` from our Rust contract becomes `{increment: {}}` in our JavaScript.
 
 ```js
-import { calculateFee } from "@cosmjs/stargate";
-
 const incrementCounter = async () => {
   // Your contract address
   const ContractAddress = process.env.CONTRACT_ADDRESS;
+  
   // Tx arguments
   let entrypoint = {
     increment: {}
   };
-  // Gas fee estimation
-  let txFee = calculateFee(300000, gasPrice);
+
   // Send Tx
-  let tx = await CosmWasmClient.execute(userAddress, ContractAddress, entrypoint, txFee);
+  let tx = await CosmWasmClient.execute(userAddress, ContractAddress, entrypoint, "auto");
   console.log('Increment Tx', tx);
 }
 ```

--- a/docs/create/guides/nft-project/dapp.mdx
+++ b/docs/create/guides/nft-project/dapp.mdx
@@ -44,7 +44,6 @@ doGetNfts();
 ## Minting from the dApp
 
 To mint from our dApp, we need to assemble the metadata fields for the NFT. We can achieve this by making a web UI with form fields where the NFT creator can add custom traits to their NFT.
-```
 
 We can simplify our remaining task by writing a function which takes the required NFT metadata as parameters. With that in mind, here's what a minting function looks like in JavaScript:
 

--- a/docs/create/guides/nft-project/dapp.mdx
+++ b/docs/create/guides/nft-project/dapp.mdx
@@ -152,7 +152,7 @@ doTransferNft();
 
 ## Displaying NFTs
 
-The `getNfts` function we created returns all token ids minted by the contract, but one more step is needed before we can display NFTs from our collection in our dApp. To read an NFT's metadata we call the [nft_info](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) entrypoint we executed from CLI in the [previous lesson](interact.md).
+The `getNfts` function we created returns all token ids minted by the contract, but one more step is needed before we can display NFTs from our collection in our dApp. To read an NFT's metadata we call the [nft_info](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) entrypoint we executed from CLI in the [previous lesson](/interact).
 
 Here's what loading token metadata looks like using JavaScript:
 

--- a/docs/create/guides/nft-project/dapp.mdx
+++ b/docs/create/guides/nft-project/dapp.mdx
@@ -152,7 +152,7 @@ doTransferNft();
 
 ## Displaying NFTs
 
-The `getNfts` function we created returns all token ids minted by the contract, but one more step is needed before we can display NFTs from our collection in our dApp. To read an NFT's metadata we call the [nft_info](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) entrypoint we executed from CLI in the [previous lesson](./interact.md).
+The `getNfts` function we created returns all token ids minted by the contract, but one more step is needed before we can display NFTs from our collection in our dApp. To read an NFT's metadata we call the [nft_info](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) entrypoint we executed from CLI in the [previous lesson](interact.md).
 
 Here's what loading token metadata looks like using JavaScript:
 

--- a/docs/create/guides/nft-project/dapp.mdx
+++ b/docs/create/guides/nft-project/dapp.mdx
@@ -152,7 +152,7 @@ doTransferNft();
 
 ## Displaying NFTs
 
-The `getNfts` function we created returns all token ids minted by the contract, but one more step is needed before we can display NFTs from our collection in our dApp. To read an NFT's metadata we call the [nft_info](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) entrypoint we executed from CLI in the [previous lesson](/docs/create/guides/nft-project/interact.md).
+The `getNfts` function we created returns all token ids minted by the contract, but one more step is needed before we can display NFTs from our collection in our dApp. To read an NFT's metadata we call the [nft_info](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) entrypoint we executed from CLI in the [previous lesson](./interact.md).
 
 Here's what loading token metadata looks like using JavaScript:
 

--- a/docs/create/guides/nft-project/dapp.mdx
+++ b/docs/create/guides/nft-project/dapp.mdx
@@ -152,7 +152,7 @@ doTransferNft();
 
 ## Displaying NFTs
 
-The `getNfts` function we created returns all token ids minted by the contract, but one more step is needed before we can display NFTs from our collection in our dApp. To read an NFT's metadata we call the [nft_info](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) entrypoint we executed from CLI in the [previous lesson](./interact.md).
+The `getNfts` function we created returns all token ids minted by the contract, but one more step is needed before we can display NFTs from our collection in our dApp. To read an NFT's metadata we call the [nft_info](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) entrypoint we executed from CLI in the [previous lesson](/docs/create/guides/nft-project/interact.md).
 
 Here's what loading token metadata looks like using JavaScript:
 

--- a/docs/create/guides/nft-project/dapp.mdx
+++ b/docs/create/guides/nft-project/dapp.mdx
@@ -8,7 +8,6 @@ If it's is your first time building an Archway dApp frontend, head over to the [
 ## Loading NFT the collection
 
 As we saw in the previous guide, to query a contract we need to know its address on chain. We also need an instance of `SigningCosmWasmClient` from `@cosmjs/cosmwasm-stargate` that's been connected to an Archway network such as [Constantine testnet](https://rpc.constantine-1.archway.tech/).
-
 ```js
 // For more on setting up this handler see the "Creating Your First dApp" guide (linked to above):
 const queryHandler = CosmWasmClient.queryClient.wasm.queryContractSmart;
@@ -45,14 +44,6 @@ doGetNfts();
 ## Minting from the dApp
 
 To mint from our dApp, we need to assemble the metadata fields for the NFT. We can achieve this by making a web UI with form fields where the NFT creator can add custom traits to their NFT.
-
-<!-- [screenshot goes here] -->
-
-We also need the `calculateFee` and `GasPrice` functions from the [@cosmjs/stargate](https://www.npmjs.com/package/@cosmjs/stargate) package.
-
-```js
-const gasPrice = GasPrice.fromString('0.002uconst');
-const txFee = calculateFee(300000, this.gas.price);
 ```
 
 We can simplify our remaining task by writing a function which takes the required NFT metadata as parameters. With that in mind, here's what a minting function looks like in JavaScript:
@@ -85,7 +76,7 @@ async function mintNft(owner, tokenId, imageUrl, name, description, attributes =
 
   try {
     // Send Tx
-    let tx = await CosmWasmClient.execute(owner, contract, entrypoint, txFee);
+    let tx = await CosmWasmClient.execute(owner, contract, entrypoint, "auto");
     console.log('Mint Tx', tx);
     // Refresh the NFT collection to resolve the new token
     await getNfts();
@@ -115,7 +106,7 @@ doMintNft();
 
 ## Transferring NFTs 
 
-Now that we can mint from our dApp, the form and entrypoint parameters for transferring NFTs are much simpler. Just like transfers initiated from the [Developer CLI](https://www.npmjs.com/package/@archwayhq/cli), we need the recipient's Archway address and the `token_id` we are sending to them. We also need to know the address of the current owner, and the references to the `contract` address and `txFee` that we set up earlier.
+Now that we can mint from our dApp, the form and entrypoint parameters for transferring NFTs are much simpler. Just like transfers initiated from the [Developer CLI](https://www.npmjs.com/package/@archwayhq/cli), we need the recipient's Archway address and the `token_id` we are sending to them. We also need to know the address of the current owner, and a reference to the `contract` address that we set up earlier. For gas fees, we can use the "auto" mode as long as we initialized our `SigningCosmWasmClient` with a gas price.
 
 Here's what a JavaScript function to transfer an Archway NFT looks like:
 
@@ -134,7 +125,7 @@ async function transferNft(owner, recipient, tokenId) {
   };
   // Send Tx
   try {
-    let tx = await CosmWasmClient.execute(owner, contract, entrypoint, txFee);
+    let tx = await CosmWasmClient.execute(owner, contract, entrypoint, "auto");
     console.log('Transfer Tx', tx);
     // Refresh the NFT collection
     await getNfts();

--- a/docs/create/guides/nft-project/dapp.mdx
+++ b/docs/create/guides/nft-project/dapp.mdx
@@ -152,7 +152,7 @@ doTransferNft();
 
 ## Displaying NFTs
 
-The `getNfts` function we created returns all token ids minted by the contract, but one more step is needed before we can display NFTs from our collection in our dApp. To read an NFT's metadata we call the [nft_info](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) entrypoint we executed from CLI in the [previous lesson](/interact).
+The `getNfts` function we created returns all token ids minted by the contract, but one more step is needed before we can display NFTs from our collection in our dApp. To read an NFT's metadata we call the [nft_info](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) entrypoint we executed from CLI in the [previous lesson](https://docs.archway.io/docs/create/guides/nft-project/interact).
 
 Here's what loading token metadata looks like using JavaScript:
 


### PR DESCRIPTION
This PR updates the developer guides with information explaining how to use the `"auto"` mode for estimating gas in dapp frontends. It replaces previous logic which used `calculateFee` to manually calculate gas for each transaction.

Additionally, this PR is linked with this commit: https://github.com/archway-network/dapp-examples/commit/cbddd72963a8abdd7a037aa63c5d537228af65fb

The above commit updates the dapp examples repo to use automatic gas estimation in place of manually calculating fees.