### PR TITLE
Changed dApps to Dapps

### DIFF
--- a/docs/create/getting-started/install.mdx
+++ b/docs/create/getting-started/install.mdx
@@ -39,7 +39,7 @@ If you didn't install  `rustc` with `rustup`, or don't have `cargo` in your comm
 
 The `cargo-generate` tool creates a new Rust project quickly by leveraging a pre-existing code base.
 
-Archway uses `cargo-generate` and `cargo-run-script` to provide and manage project templates for dApp development.
+Archway uses `cargo-generate` and `cargo-run-script` to provide and manage project templates for dapp development.
 
 To install `cargo-generate` with `vendored-openssl`, and the `cargo-run-script` module, run the commands:
 

--- a/docs/create/guides/launchpad.md
+++ b/docs/create/guides/launchpad.md
@@ -8,5 +8,5 @@ description: Your launchpad into Cosmos and beyond. Level up your ecosystem with
 
 Your launchpad into Cosmos and beyond.
 
-- [Build Your First dApp](./my-first-dapp/start.md)
+- [Build Your First dapp](./my-first-dapp/start.md)
 - [Build With NFTs](./nft-project/start.md)

--- a/docs/create/guides/my-first-dapp/_category_.json
+++ b/docs/create/guides/my-first-dapp/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Creating Your First dApp",
+  "label": "Creating Your First Dapp",
   "position": 2
 }

--- a/docs/create/guides/my-first-dapp/_category_.json
+++ b/docs/create/guides/my-first-dapp/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Creating Your First Dapp",
+  "label": "Creating Your First dapp",
   "position": 2
 }

--- a/docs/create/guides/my-first-dapp/dapp.mdx
+++ b/docs/create/guides/my-first-dapp/dapp.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 6
 ---
 
-# Building a dApp frontend
+# Building a dapp frontend
 
 For building web frontends, you'll need the following [npm](https://www.npmjs.com/) packages to connect your web page to Archway Network.
 
@@ -66,7 +66,7 @@ async function connectKeplrWallet() {
         { gasPrice: gasPrice }
       );
      
-      // This async waits for the user to authorize your dApp
+      // This async waits for the user to authorize your dapp
       // it returns their account address only after permissions
       // to read that address are granted
       accounts = await this.offlineSigner.getAccounts();
@@ -149,7 +149,7 @@ const incrementCounter = async () => {
 
 ## Clone it and try yourself
 
-You'll find working examples of dApp frontends for the Increment starter code template in the [dApp examples repository](https://github.com/archway-network/dApp-examples). Examples are given in both [Vue.js](https://vuejs.org/) and [React](https://reactjs.org/).
+You'll find working examples of dapp frontends for the Increment starter code template in the [dapp examples repository](https://github.com/archway-network/dApp-examples). Examples are given in both [Vue.js](https://vuejs.org/) and [React](https://reactjs.org/).
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/create/guides/my-first-dapp/deploy.md
+++ b/docs/create/guides/my-first-dapp/deploy.md
@@ -34,7 +34,7 @@ archway store
 
 ## Instatiating the contract
 
-To skip the CLI asking for default values required by your dApp, include constructor arguments using the `--args` parameter. Format your constructor parameters as a `JSON` encoded string.
+To skip the CLI asking for default values required by your dapp, include constructor arguments using the `--args` parameter. Format your constructor parameters as a `JSON` encoded string.
 
 ```bash
 archway instantiate --args '{"my_key":"my value"}'
@@ -49,7 +49,7 @@ archway instantiate --args '{"count":0}'
 ```
 
 :::note
-If you instantiate without using `--args` you'll be prompted by the CLI to enter that information. If your dApp contract doesn't take any constructor arguments use `'{}'` to denote `null` arguments.
+If you instantiate without using `--args` you'll be prompted by the CLI to enter that information. If your dapp contract doesn't take any constructor arguments use `'{}'` to denote `null` arguments.
 :::
 
 So why are we sending our constructor as `{"count":0}` and how can we verify it's correct?

--- a/docs/create/guides/my-first-dapp/faucet.md
+++ b/docs/create/guides/my-first-dapp/faucet.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Requesting Testnet funds
 
-If you're working on a testnet you'll want testnet `$ARCH` for paying gas costs to deploy your dApp code on chain.
+If you're working on a testnet you'll want testnet `$ARCH` for paying gas costs to deploy your dapp code on chain.
 
 After [creating an account](../../getting-started/setup.md#creating-an-account), to request funds from the faucet use our Discord channel.
 

--- a/docs/create/guides/my-first-dapp/start.md
+++ b/docs/create/guides/my-first-dapp/start.md
@@ -12,7 +12,7 @@ This guide follows the below workflow:
 4. [Produce _default_ and _CosmWasm_ `wasm` binaries](./wasm.md)
 5. [Deploy to a testnet](./deploy.md)
 6. [Query and transact with a deployed contract](./interact.md)
-7. [Building a dApp frontend](./dapp.mdx)
+7. [Building a dapp frontend](./dapp.mdx)
 
 ## Creating a project
 

--- a/docs/create/guides/my-first-dapp/wasm.md
+++ b/docs/create/guides/my-first-dapp/wasm.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 # Producing Wasm executables
 
 Since we've tested and built our contract, we're still operating under the assumption that everything works.
-However, to test our dApp on Archway, we'll need to build it as a `wasm` executable, then upload and instantiate it on chain.
+However, to test our dapp on Archway, we'll need to build it as a `wasm` executable, then upload and instantiate it on chain.
 
 For that, you'll need the `wasm32-unknown-unknown` target installed in your toolchain as well. You can add it using:
 

--- a/docs/create/guides/nft-project/dapp.mdx
+++ b/docs/create/guides/nft-project/dapp.mdx
@@ -1,9 +1,9 @@
 ---
 sidebar_position: 4
-title: Building the NFT Dapp
+title: Building the NFT dapp
 ---
 
-If it's is your first time building an Archway dapp frontend, head over to the [Creating Your First dApp](../my-first-dapp/dapp.mdx) guide to learn how to setup your basic project scaffolding. Once you're serving a web page that connects to [Keplr](https://wallet.keplr.app/), you'll be ready to follow the next steps.
+If it's is your first time building an Archway dapp frontend, head over to the [Creating Your First dapp](../my-first-dapp/dapp.mdx) guide to learn how to setup your basic project scaffolding. Once you're serving a web page that connects to [Keplr](https://wallet.keplr.app/), you'll be ready to follow the next steps.
 
 ## Loading NFT the collection
 

--- a/docs/create/guides/nft-project/dapp.mdx
+++ b/docs/create/guides/nft-project/dapp.mdx
@@ -1,15 +1,15 @@
 ---
 sidebar_position: 4
-title: Building the NFT dApp
+title: Building the NFT Dapp
 ---
 
-If it's is your first time building an Archway dApp frontend, head over to the [Creating Your First dApp](../my-first-dapp/dapp.mdx) guide to learn how to setup your basic project scaffolding. Once you're serving a web page that connects to [Keplr](https://wallet.keplr.app/), you'll be ready to follow the next steps.
+If it's is your first time building an Archway dapp frontend, head over to the [Creating Your First dApp](../my-first-dapp/dapp.mdx) guide to learn how to setup your basic project scaffolding. Once you're serving a web page that connects to [Keplr](https://wallet.keplr.app/), you'll be ready to follow the next steps.
 
 ## Loading NFT the collection
 
 As we saw in the previous guide, to query a contract we need to know its address on chain. We also need an instance of `SigningCosmWasmClient` from `@cosmjs/cosmwasm-stargate` that's been connected to an Archway network such as [Constantine testnet](https://rpc.constantine-1.archway.tech/).
 ```js
-// For more on setting up this handler see the "Creating Your First dApp" guide (linked to above):
+// For more on setting up this handler see the "Creating Your First dapp" guide (linked to above):
 const queryHandler = CosmWasmClient.queryClient.wasm.queryContractSmart;
 // Replace this empty string with your deployed contract address
 const contract = "";
@@ -41,9 +41,9 @@ async function doGetNfts() {
 doGetNfts();
 ```
 
-## Minting from the dApp
+## Minting from the dapp
 
-To mint from our dApp, we need to assemble the metadata fields for the NFT. We can achieve this by making a web UI with form fields where the NFT creator can add custom traits to their NFT.
+To mint from our dapp, we need to assemble the metadata fields for the NFT. We can achieve this by making a web UI with form fields where the NFT creator can add custom traits to their NFT.
 
 We can simplify our remaining task by writing a function which takes the required NFT metadata as parameters. With that in mind, here's what a minting function looks like in JavaScript:
 
@@ -105,7 +105,7 @@ doMintNft();
 
 ## Transferring NFTs 
 
-Now that we can mint from our dApp, the form and entrypoint parameters for transferring NFTs are much simpler. Just like transfers initiated from the [Developer CLI](https://www.npmjs.com/package/@archwayhq/cli), we need the recipient's Archway address and the `token_id` we are sending to them. We also need to know the address of the current owner, and a reference to the `contract` address that we set up earlier. For gas fees, we can use the "auto" mode as long as we initialized our `SigningCosmWasmClient` with a gas price.
+Now that we can mint from our dapp, the form and entrypoint parameters for transferring NFTs are much simpler. Just like transfers initiated from the [Developer CLI](https://www.npmjs.com/package/@archwayhq/cli), we need the recipient's Archway address and the `token_id` we are sending to them. We also need to know the address of the current owner, and a reference to the `contract` address that we set up earlier. For gas fees, we can use the "auto" mode as long as we initialized our `SigningCosmWasmClient` with a gas price.
 
 Here's what a JavaScript function to transfer an Archway NFT looks like:
 
@@ -151,7 +151,7 @@ doTransferNft();
 
 ## Displaying NFTs
 
-The `getNfts` function we created returns all token ids minted by the contract, but one more step is needed before we can display NFTs from our collection in our dApp. To read an NFT's metadata we call the [nft_info](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) entrypoint we executed from CLI in the [previous lesson](https://docs.archway.io/docs/create/guides/nft-project/interact).
+The `getNfts` function we created returns all token ids minted by the contract, but one more step is needed before we can display NFTs from our collection in our dapp. To read an NFT's metadata we call the [nft_info](https://github.com/CosmWasm/cw-nfts/blob/v0.9.3/contracts/cw721-base/src/query.rs#L33-L39) entrypoint we executed from CLI in the [previous lesson](https://docs.archway.io/docs/create/guides/nft-project/interact).
 
 Here's what loading token metadata looks like using JavaScript:
 
@@ -188,7 +188,7 @@ doGetTokenMeta();
 
 ## Clone it and try yourself
 
-This guide focused on core features of Archway NFTs, some basic aspects of web development haven't been looked at in detail, but you'll find working example frontends for this project in the [dApp examples repository](https://github.com/archway-network/dApp-examples).
+This guide focused on core features of Archway NFTs, some basic aspects of web development haven't been looked at in detail, but you'll find working example frontends for this project in the [dapp examples repository](https://github.com/archway-network/dApp-examples).
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/create/guides/nft-project/deploy.md
+++ b/docs/create/guides/nft-project/deploy.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Deploying the token contract
 
-As we saw in the [My First dApp](../my-first-dapp/deploy.md) guide, deployment on Archway is a multi-step process.
+As we saw in the [My First dapp](../my-first-dapp/deploy.md) guide, deployment on Archway is a multi-step process.
 
 1. [Generate an optimized build](#generate-an-optimized-build)
 2. [Store the optimized build on chain](#store-the-optimized-build-on-chain)

--- a/docs/create/guides/nft-project/interact.md
+++ b/docs/create/guides/nft-project/interact.md
@@ -81,4 +81,4 @@ archway query contract-state smart --args '{"nft_info":{"token_id":"1"}}'
 # Show output here
 ```
 
-Now that the contract is up and running, read on to learn how to build a dApp around the minting and transfer functionality we just tested.
+Now that the contract is up and running, read on to learn how to build a dapp around the minting and transfer functionality we just tested.

--- a/docs/create/guides/nft-project/start.md
+++ b/docs/create/guides/nft-project/start.md
@@ -10,14 +10,14 @@ This guide follows the below workflow:
 2. [Customizing your token parameters](#designing-your-tokens)
 3. [Deploying your token contract](./deploy.md)
 4. [Minting and sending tokens](./interact.md)
-5. [Building the NFT dApp](./dapp.mdx)
+5. [Building the NFT dapp](./dapp.mdx)
 
 
 ## Introduction
 
 Non-Fungible Tokens, or NFTs, have been a hot topic during this past year. They've quickly become an essential component of the decentralized digital world. 
 
-In this guide, we will learn how to write, deploy, mint and transfer our own NFTs. We'll also learn how to build a dApp website we can share with other users, so they can also mint and transfer tokens.
+In this guide, we will learn how to write, deploy, mint and transfer our own NFTs. We'll also learn how to build a dapp website we can share with other users, so they can also mint and transfer tokens.
 
 ## Creating your project
 

--- a/docs/overview/about.md
+++ b/docs/overview/about.md
@@ -6,9 +6,9 @@ description: A self-sovereign blockchain network that allows developers to expre
 
 # About Archway
 
-Archway is an incentivized smart contract platform that rewards developers — ushering in next gen dApps.
+Archway is an incentivized smart contract platform that rewards developers — ushering in next gen dapps.
 
-The protocol gives developers the tools to quickly build and launch scalable cross-chain dApps and get rewarded for the value the dApps contribute to the network.
+The protocol gives developers the tools to quickly build and launch scalable cross-chain dapps and get rewarded for the value the dapps contribute to the network.
 
 ## The Archway Mission
 
@@ -16,7 +16,7 @@ The overarching goal of Archway is to foster an array of diverse and sustainable
 
 The internet helped democratize access to information, but it hasn't fully democratized access to capital and value. Entrepreneurs and developers worldwide lack access to the same opportunities as their counterparts in more developed nations.
 
-Archway aims to level the playing field. Built into the protocol itself, Archway rewards developers based on the value and impact of their dApp, rather than their close association or connections to capital. 
+Archway aims to level the playing field. Built into the protocol itself, Archway rewards developers based on the value and impact of their dapp, rather than their close association or connections to capital. 
 
 Unlike existing Web 2.0 platforms or early versions of Web 3 Layer-1s, where tokens are mostly concentrated in the hands of the first few early participants, Archway is designed to be shared across all contributors and stakeholders. The entrepreneurs and developers who are building on Archway get a true stake in the growth and governance of the protocol itself.
 
@@ -42,7 +42,7 @@ The Archway protocol uses CosmWasm, WebAssembly (Wasm), and Rust. Over 40 high-l
 
 #### Difference Between Smart Contracts and Cosmos Chains
 
-While the ethos of Cosmos is for developers to create their own self-sovereign chains, in many cases, it makes sense for a project to first deploy as a dApp. There is a lot of overhead in launching and maintaining a standalone chain. While the Cosmos SDK simplifies much of the technical effort, a developer still needs to attract and sufficiently incentivize a strong community of validators to run the network. These efforts and coordination can be a daunting endeavor for early projects.
+While the ethos of Cosmos is for developers to create their own self-sovereign chains, in many cases, it makes sense for a project to first deploy as a dapp. There is a lot of overhead in launching and maintaining a standalone chain. While the Cosmos SDK simplifies much of the technical effort, a developer still needs to attract and sufficiently incentivize a strong community of validators to run the network. These efforts and coordination can be a daunting endeavor for early projects.
 
 Consider the following tradeoffs between building your core logic as a smart contract versus building your logic as an independent Cosmos blockchain.
 
@@ -84,25 +84,25 @@ The Cosmos SDK does not support post-transaction processing. Archway takes into 
 
 ## Economic Overview
 
-With Archway, dApps can earn a portion of transaction fees and inflationary rewards in exchange for their contributions to the network. This earning model is similar to how validators are rewarded for operating nodes in a typical Proof-of-Stake (PoS) chain. 
+With Archway, dapps can earn a portion of transaction fees and inflationary rewards in exchange for their contributions to the network. This earning model is similar to how validators are rewarded for operating nodes in a typical Proof-of-Stake (PoS) chain. 
  
-Archway seeks to provide three potential funding sources for dApps:
+Archway seeks to provide three potential funding sources for dapps:
 
 - Gas fee rebates 
 - Share of inflationary rewards
 - Smart contract fees (optional)
 
-Archway allows each dApp developer and their community to configure how the rewards are managed and distributed. When a contract is instantiated, the dApp creator specifies an `owner` address where all fees and rewards are automatically deposited. This target address can be the creator's address, a multisig, or an address that is controlled by a separate custom contract. Ownership can then be transferred to a new address as needed. Ownership transfer requires only the signature of the previous owner. 
+Archway allows each dapp developer and their community to configure how the rewards are managed and distributed. When a contract is instantiated, the dapp creator specifies an `owner` address where all fees and rewards are automatically deposited. This target address can be the creator's address, a multisig, or an address that is controlled by a separate custom contract. Ownership can then be transferred to a new address as needed. Ownership transfer requires only the signature of the previous owner. 
 
 <!-- Economics : Gas Rebates -->
 
 ### Gas Rebates 
 
-Unlike existing smart contract platforms, Archway does not burn gas fees or distribute them entirely to the validators or miners. Instead, the collected gas fees are split between dApp developers and validators.
+Unlike existing smart contract platforms, Archway does not burn gas fees or distribute them entirely to the validators or miners. Instead, the collected gas fees are split between dapp developers and validators.
 
-At network launch, gas fees are divided evenly with 50% going to dApp developers and 50% to validators. The network provides configurable parameters that can be adjusted over time to determine the optimal gas rebate distribution between validators and dApps.
+At network launch, gas fees are divided evenly with 50% going to dapp developers and 50% to validators. The network provides configurable parameters that can be adjusted over time to determine the optimal gas rebate distribution between validators and dapps.
 
-From the dApp developer perspective, a contract receives a 50% rebate on all gas paid. From the validator perspective, deferring a portion of rewards in the near term effectively drives transaction volumes, fees, and increases the value of the underlying network in the future.
+From the dapp developer perspective, a contract receives a 50% rebate on all gas paid. From the validator perspective, deferring a portion of rewards in the near term effectively drives transaction volumes, fees, and increases the value of the underlying network in the future.
 
 It would not be profitable for an attacker to spam transactions on the network as gas rebates recoup only part of the fees paid (50%). As an additional safeguard against potential abuse and to prevent the deployment of spam contracts, gas fees are higher for uploading new contracts than for routine transactions. Gas fees are still sufficiently low to allow smaller projects to upload contracts.
 
@@ -114,11 +114,11 @@ Gas fee rebates are automatically paid out by the network on a per-block basis.
 
 The overall inflation rate on the Archway network follows the model of the [mint module](https://github.com/gavinly/CosmosParametersWiki/blob/master/Mint.md) in the Cosmos Hub, with total token supply increasing between 7% and 20% annually, depending on the ratio of tokens that are actively staked on the network.
 
-The Archway protocol then shares a portion of these total inflation rewards directly with dApps. At genesis, 25% of inflation rewards go to dApp developers and 75% go to validators. For example, if the network sees total annual inflation of 8%, then 2% goes to dApps and 6% goes to validators. These distribution values are configurable parameters that can be adjusted by the Archway community through network governance.
+The Archway protocol then shares a portion of these total inflation rewards directly with dapps. At genesis, 25% of inflation rewards go to dapp developers and 75% go to validators. For example, if the network sees total annual inflation of 8%, then 2% goes to dapps and 6% goes to validators. These distribution values are configurable parameters that can be adjusted by the Archway community through network governance.
 
-The dApp rewards pool (2% in the previous example) is then proportionally distributed based on the relative amount of gas fees that each dApp generates within a given epoch. For example, a dApp that is responsible for 10% of gas consumption is awarded 10% of the available pool.
+The dapp rewards pool (2% in the previous example) is then proportionally distributed based on the relative amount of gas fees that each dapp generates within a given epoch. For example, a dapp that is responsible for 10% of gas consumption is awarded 10% of the available pool.
 
-To mitigate potential Sybil attacks and ensure spamming transactions is not profitable, each dApp has a max inflation rewards cap. At network launch, there is a hard cap based on the total gas fees paid per dApp. A contract deployed to Archway cannot earn rewards greater than the total gas it generates within an epoch. Implementation of a dynamic rewards cap is being actively researched and can be updated through future governance. Transitioning to a floating cap provides more flexible distribution and further incentivizes developers to continuously improve their dApps.
+To mitigate potential Sybil attacks and ensure spamming transactions is not profitable, each dApp has a max inflation rewards cap. At network launch, there is a hard cap based on the total gas fees paid per dapp. A contract deployed to Archway cannot earn rewards greater than the total gas it generates within an epoch. Implementation of a dynamic rewards cap is being actively researched and can be updated through future governance. Transitioning to a floating cap provides more flexible distribution and further incentivizes developers to continuously improve their dapps.
 
 Any surplus in rewards is contributed to the Archway community pool where the funds are managed through governance.
 
@@ -129,47 +129,47 @@ Inflationary rewards are paid out by the network on a per-block basis.
 
 ### Example Use Cases
 
-dApps can choose to allocate the rewards they accrue in whatever way is most beneficial to their ecosystem. For instance, rewards can be redistributed to governance token holders, used to support core development teams, cover users’ gas fees, seed liquidity pools, contribute to a community DAO, open project bounties, sponsor events or hackathons, and much more.
+Dapps can choose to allocate the rewards they accrue in whatever way is most beneficial to their ecosystem. For instance, rewards can be redistributed to governance token holders, used to support core development teams, cover users’ gas fees, seed liquidity pools, contribute to a community DAO, open project bounties, sponsor events or hackathons, and much more.
 
 
 #### Governance Rewards
 
-A recent trend has dApps issuing governance tokens to incentivize and bootstrap early communities. This token distribution has proved to be very successful in a number of cases,  despite the dApp not having any clear mechanism for value capture for fees or revenues. Some of these tokens merely grant voting rights, but have still been the subject of intense growth due to speculation of future utility of the dApp or potential rights to cash flows by governance token holders. 
+A recent trend has dapps issuing governance tokens to incentivize and bootstrap early communities. This token distribution has proved to be very successful in a number of cases,  despite the dapp not having any clear mechanism for value capture for fees or revenues. Some of these tokens merely grant voting rights, but have still been the subject of intense growth due to speculation of future utility of the dapp or potential rights to cash flows by governance token holders. 
 
-In the Archway model, dApp developers can redistribute their share of network rewards directly to their governance token holders, subject to local securities laws. The Archway model turns standard governance tokens into productive, yield-generating assets. 
+In the Archway model, dapp developers can redistribute their share of network rewards directly to their governance token holders, subject to local securities laws. The Archway model turns standard governance tokens into productive, yield-generating assets. 
 
-While individual dApps on other networks, such as SushiSwap, have implemented similar functionality, the Archway protocol makes it possible to implement and manage governance rewards at the protocol level itself. A developer can opt-in and automatically redirect to governance token holders the funds earned by the dApp, including gas rebates, inflation rewards, and even smart contract fees. 
+While individual dapps on other networks, such as SushiSwap, have implemented similar functionality, the Archway protocol makes it possible to implement and manage governance rewards at the protocol level itself. A developer can opt-in and automatically redirect to governance token holders the funds earned by the dapp, including gas rebates, inflation rewards, and even smart contract fees. 
 
 
 #### Support the Core Development Team
 
-Rewards offered by Archway could help developers bootstrap new projects without having to dedicate excessive time and focus to fundraising. The process of raising early capital can be difficult for developers of individual dApps. 
+Rewards offered by Archway could help developers bootstrap new projects without having to dedicate excessive time and focus to fundraising. The process of raising early capital can be difficult for developers of individual dapps. 
 
-Development teams often resort to private insider sales that skew early token distribution or are forced to rely on foundation grant programs. Rather than prioritizing the best technology and ecosystem for their dApp, developers often choose a tech stack that is based on available grants and are then locked into a single platform.
+Development teams often resort to private insider sales that skew early token distribution or are forced to rely on foundation grant programs. Rather than prioritizing the best technology and ecosystem for their dapp, developers often choose a tech stack that is based on available grants and are then locked into a single platform.
 
-Even after a dApp is launched, developers continuing to support the dApp codebase may find it difficult to cover ongoing development costs as the blockchain industry is still nascent and winning business models have yet to materialize.
+Even after a dapp is launched, developers continuing to support the dapp codebase may find it difficult to cover ongoing development costs as the blockchain industry is still nascent and winning business models have yet to materialize.
 
-The model introduced by Archway can counter some of these early financial pressures by allocating dApp rewards directly to core development teams. This funding source could serve as a supplement to help sustain projects and allow the team to focus on what really matters — shipping the best possible product, growing their user base, and supporting the community.
+The model introduced by Archway can counter some of these early financial pressures by allocating dapp rewards directly to core development teams. This funding source could serve as a supplement to help sustain projects and allow the team to focus on what really matters — shipping the best possible product, growing their user base, and supporting the community.
 
 
 #### Subsidize Gas Payments
 
-Gas payments remain one of the critical barriers to delivering a simple, intuitive user experience for dApps. Archway supports gasless transactions through the use of pool accounts. A dApp can pull funds from a common pool to sponsor gas payments and completely abstract away that complexity and friction for their end users.
+Gas payments remain one of the critical barriers to delivering a simple, intuitive user experience for dapps. Archway supports gasless transactions through the use of pool accounts. A dapp can pull funds from a common pool to sponsor gas payments and completely abstract away that complexity and friction for their end users.
 
-To fund the pool account balance, a developer can use the fees and rewards generated by the dApp itself. In effect, the dApp gets a 50% discount on each transaction from gas rebates along with inflation rewards and contract fees that are potentially available as a bonus. 
+To fund the pool account balance, a developer can use the fees and rewards generated by the dapp itself. In effect, the dApp gets a 50% discount on each transaction from gas rebates along with inflation rewards and contract fees that are potentially available as a bonus. 
 
-By recycling these funds, dApps have the option to dramatically reduce or eliminate the gas burden for end users, leading to a smoother onboarding process and stronger retention over time.
+By recycling these funds, dapps have the option to dramatically reduce or eliminate the gas burden for end users, leading to a smoother onboarding process and stronger retention over time.
 
 
 #### Fund a Decentralized Autonomous Organization (DAO)
 
-Rewards generated by a dApp can be contributed to a community-owned DAO that is focused on coordinating and funding critical work for its ecosystem. These rewards can be continuously deposited to the DAO treasury that allows members to collectively manage and deploy the assets based on specific needs of the project.
+Rewards generated by a dapp can be contributed to a community-owned DAO that is focused on coordinating and funding critical work for its ecosystem. These rewards can be continuously deposited to the DAO treasury that allows members to collectively manage and deploy the assets based on specific needs of the project.
 
 This DAO could then vote to fund core development teams, sponsor events and hackathons, commission code audits, open bug bounties, launch education programs, subsidize third-party integrations, and so on. DAO funding could be available to anything and everything that could potentially benefit and impact the ecosystem.
 
 The DAO itself can exist and operate as a set of smart contracts on top of Archway, so the entire process is automated and transparent throughout initial rewards collection, voting, grants distribution, and so on.
 
-Giving members collective control over a recurring funding source helps actively engage the dApp’s community and contributes toward progressively decentralizing the project itself.
+Giving members collective control over a recurring funding source helps actively engage the dapp’s community and contributes toward progressively decentralizing the project itself.
 
 #### Boost Liquidity Mining Programs
 
@@ -191,13 +191,13 @@ By deploying to Archway, DEXs could be constructed to effectively eliminate one 
 
 Smart contract platforms today charge network fees (“gas”) based on the amount of computational processing required by on-chain transactions. While this method of measurement works for the underlying economics of a network, it does not support use cases where a developer has to cover additional costs such as distributed storage, access to off-chain processing, external data sources, or other premium features such as audited and insured contracts. 
 
-With Archway, developers of dApps can define custom fees for interacting with their smart contracts. Also known as the _take rate_, this fee provides developers a flexible option to charge different fee levels that are based on their specific use case and operational needs.
+With Archway, developers of dapps can define custom fees for interacting with their smart contracts. Also known as the _take rate_, this fee provides developers a flexible option to charge different fee levels that are based on their specific use case and operational needs.
 
-By default, the smart contract fee is set to 0 $ARCH. On initial deployment, the dApp developer can define their fee. The fee is configurable and the dApp owner can adjust it any time, even after the contract has been deployed.
+By default, the smart contract fee is set to 0 $ARCH. On initial deployment, the dapp developer can define their fee. The fee is configurable and the dapp owner can adjust it any time, even after the contract has been deployed.
 
 To streamline the user experience, the smart contract fee is embedded directly in the network fee, so end users are simply presented with a single combined fee when signing a transaction.
 
-Since most dApps are composed of smaller, more modular pieces of code and layers of contracts, individual developers can focus on building even smaller snippets of code. They can write and monetize a single contract rather than a fully featured dApp. Since contracts can be integrated into multiple dApps, developers can earn multiple lines of fees across any user base that interacts with their code. Imagine, for example, the rapid app development that would happen if every NPM package earns fees for computational use.
+Since most dapps are composed of smaller, more modular pieces of code and layers of contracts, individual developers can focus on building even smaller snippets of code. They can write and monetize a single contract rather than a fully featured dapp. Since contracts can be integrated into multiple dapps, developers can earn multiple lines of fees across any user base that interacts with their code. Imagine, for example, the rapid app development that would happen if every NPM package earns fees for computational use.
 
 <!-- Governance -->
 

--- a/docs/overview/about.md
+++ b/docs/overview/about.md
@@ -118,7 +118,7 @@ The Archway protocol then shares a portion of these total inflation rewards dire
 
 The dapp rewards pool (2% in the previous example) is then proportionally distributed based on the relative amount of gas fees that each dapp generates within a given epoch. For example, a dapp that is responsible for 10% of gas consumption is awarded 10% of the available pool.
 
-To mitigate potential Sybil attacks and ensure spamming transactions is not profitable, each dApp has a max inflation rewards cap. At network launch, there is a hard cap based on the total gas fees paid per dapp. A contract deployed to Archway cannot earn rewards greater than the total gas it generates within an epoch. Implementation of a dynamic rewards cap is being actively researched and can be updated through future governance. Transitioning to a floating cap provides more flexible distribution and further incentivizes developers to continuously improve their dapps.
+To mitigate potential Sybil attacks and ensure spamming transactions is not profitable, each dapp has a max inflation rewards cap. At network launch, there is a hard cap based on the total gas fees paid per dapp. A contract deployed to Archway cannot earn rewards greater than the total gas it generates within an epoch. Implementation of a dynamic rewards cap is being actively researched and can be updated through future governance. Transitioning to a floating cap provides more flexible distribution and further incentivizes developers to continuously improve their dapps.
 
 Any surplus in rewards is contributed to the Archway community pool where the funds are managed through governance.
 

--- a/docs/overview/community/.community-integrations/applications.md
+++ b/docs/overview/community/.community-integrations/applications.md
@@ -4,4 +4,4 @@ sidebar_position: 2
 
 # Applications
 
-# dApps
+# Dapps

--- a/docs/overview/faq.md
+++ b/docs/overview/faq.md
@@ -8,11 +8,11 @@ Answers to frequently asked questions about Archway.
 
 ## What is Archway?
 
-Archway is an incentivized smart contract chain for the Cosmos ecosystem that allows developers to deploy high-performance dApps and get rewarded for the value they contribute to the network.
+Archway is an incentivized smart contract chain for the Cosmos ecosystem that allows developers to deploy high-performance dapps and get rewarded for the value they contribute to the network.
 
 ## Why Archway?
 
-When developers build and launch impactful dApps that generate usage on Archway, they can earn a proportional share of network fees and rewards. 
+When developers build and launch impactful dapps that generate usage on Archway, they can earn a proportional share of network fees and rewards. 
 
 This shared earning model enables developers to potentially access recurring rewards and participate in the upside of the underlying protocol. 
 

--- a/docs/overview/glossary.md
+++ b/docs/overview/glossary.md
@@ -21,9 +21,9 @@ A framework that allows developers to write multi-chain smart contracts using an
 
 <!-- D -->
 
-## dApp
+## Dapp
 
-An abbreviation of "decentralized application", dApps are applications built on Archway that combine smart contract functionality with a frontend web interface for users.
+An abbreviation of "decentralized application", dapps are applications built on Archway that combine smart contract functionality with a frontend web interface for users.
 
 <!-- E -->
 <!-- F -->
@@ -44,11 +44,11 @@ Archway will provide a native Gravity Bridge integration so developers can pull 
 
 [IBC](https://docs.cosmos.network/master/ibc/overview.html) is a generalized cross-chain communication protocol for transferring value and data between independent networks.
 
-The IBC protocol makes it possible for blockchains to connect to each other. Built on Cosmos, Archway natively integrates IBC so users can frictionlessly exchange assets and data with other Cosmos-enabled chains. dApps deploy straight to Archway and plug directly into IBC without additional development or the need to spin up an independent chain.
+The IBC protocol makes it possible for blockchains to connect to each other. Built on Cosmos, Archway natively integrates IBC so users can frictionlessly exchange assets and data with other Cosmos-enabled chains. dapps deploy straight to Archway and plug directly into IBC without additional development or the need to spin up an independent chain.
 
 This native integration helps expand a developer’s addressable market by opening up access to users and liquidity from other chains, while also allowing their token to be ported and utilized elsewhere.
 
-Archway’s native IBC integration enables developers to future-proof their dApps. Rather than betting on a single isolated chain or scaling solution and then being locked into that ecosystem, dApps built on the Archway protocol exist across an interconnected network of chains and can be migrated with ease if needed.
+Archway’s native IBC integration enables developers to future-proof their dapps. Rather than betting on a single isolated chain or scaling solution and then being locked into that ecosystem, dapps built on the Archway protocol exist across an interconnected network of chains and can be migrated with ease if needed.
 
 <!-- J -->
 <!-- K -->
@@ -61,7 +61,7 @@ Archway’s native IBC integration enables developers to future-proof their dApp
 
 ## Pool account
 
-A common liquidity pool that Archway dApps can fund and then use to sponsor gas payments for end users.
+A common liquidity pool that Archway dapps can fund and then use to sponsor gas payments for end users.
 
 <!-- Q -->
 <!-- R -->

--- a/docs/overview/network.md
+++ b/docs/overview/network.md
@@ -9,9 +9,9 @@ Network configurations for Archway Mainnet and Testnets.
 ## Triomphe (Mainnet) 
 Coming Later
 
-## Constantine (dApp Developer Testnet)
+## Constantine (Dapp Developer Testnet)
 
-Stable testing network for dApp developers building dApps.
+Stable testing network for dapp developers building dapps.
 
 - Chain ID: `constantine-1`
 - RPC: https://rpc.constantine-1.archway.tech 

--- a/docs/participate/contribute.md
+++ b/docs/participate/contribute.md
@@ -48,7 +48,7 @@ Other useful resources:
 
 #### Developer docs:
 
-_Developer docs_ refers to documentation for smart contract and dApp developers. It's content to help users build and scale dApps on Archway network and contains information that is pertinent to:
+_Developer docs_ refers to documentation for smart contract and dapp developers. It's content to help users build and scale dapps on Archway network and contains information that is pertinent to:
 - Smart Contract development
 - Web and UI frontends that connect to Archway network
 - The [Archway developer CLI](https://www.npmjs.com/package/@archwayhq/cli)
@@ -57,7 +57,7 @@ Developer docs are located in folder [/docs/create](https://github.com/archway-n
 
 #### Developer guides (tutorials):
 
-_Developer guides_ are tutorials for developing Archway smart contract and dApp projects. Each guide includes step by step instructions and final source code for a completed project to be run on Archway network.
+_Developer guides_ are tutorials for developing Archway smart contract and dapp projects. Each guide includes step by step instructions and final source code for a completed project to be run on Archway network.
 
 Developer guides are located in the folder [/docs/create/guides](https://github.com/archway-network/archway-docs/tree/main/docs/create/guides)
 


### PR DESCRIPTION
Standardizing how Dapps/dapps is written throughout the docs. Excludes main top level page.