### PR TITLE
Fixed the import of the useTOC and useCurrentPage functions

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,6 +3,7 @@
 
   import { PageBreadcrumbs, PageTOC } from '@/components/Ui';
   import Navigation from '@/components/Navigation.vue';
+  import { useTOC, useCurrentPage } from '@/composables';
 
   const { toc, displayTOC } = useTOC();
   const { page } = useCurrentPage();


### PR DESCRIPTION
The useTOC and useCurrentPage functions were being used in the default layout file but were not imported which caused an error preventing content pages from loading.