### PR TITLE
Update the required archway version from 0.0.5 to 0.2.0

### DIFF
--- a/docs/node/install.md
+++ b/docs/node/install.md
@@ -38,9 +38,9 @@ git checkout <version-tag>
 
 ```
 :::info
-For connecting to the [Constantine Developer Testnet](https://docs.archway.io/docs/overview/network#constantine-dapp-developer-testnet), the version tag v0.0.5 should be used:
+For connecting to the [Constantine Developer Testnet](https://docs.archway.io/docs/overview/network#constantine-dapp-developer-testnet), the version tag v0.2.0 should be used:
 
-`git checkout v0.0.5` 
+`git checkout v0.2.0` 
 :::
 
 


### PR DESCRIPTION
The node installation guide currently displays the incorrect Archway version to checkout for installation, which has caused issues for some node installers when connecting to the Constantine testnet.