### PR TITLE
Feature/adev 21 fix most popular

### DIFF
--- a/components/Sections/PopularArticles.vue
+++ b/components/Sections/PopularArticles.vue
@@ -2,7 +2,11 @@
   import Articles from '@/components/Articles.vue';
   import { useSectionPopularArticles } from '@/data';
 
-  const { articles, refresh } = await useSectionPopularArticles();
+  const props = defineProps({
+    rootSection: { type: String, required: true }
+  });
+
+  const { articles, refresh } = await useSectionPopularArticles(props.rootSection);
   onMounted(async () => {
     await refresh();
   });

--- a/data/useAlgoliaSearch.ts
+++ b/data/useAlgoliaSearch.ts
@@ -5,7 +5,7 @@ import { SortingReplicas } from '~~/domain/AlgoliaSearch';
 export const useAlgoliaSearch: () => Promise<{
   findObject: (searchPredicate: (hit: any) => boolean) => Promise<any>,
   updateObjectsPartially: (objs: any[], createIfNotExists?: boolean) => Promise<any>,
-  search: (query: string, sortingReplica: SortingReplicas) => Promise<any>
+  search: (query: string, sortingReplica: SortingReplicas, filters?: string) => Promise<any>
 }> = async () => {
     const { algolia } = useRuntimeConfig();
     const algoliaSearch = new AlgoliaSearch(algolia.appId, algolia.writeApiKey, algolia.docIndex);
@@ -18,8 +18,8 @@ export const useAlgoliaSearch: () => Promise<{
         return await algoliaSearch.updateObjectsPartially(objs, createIfNotExists);
     }
 
-    const search = async (query: string, sortingReplica: SortingReplicas) => {
-        return await algoliaSearch.search(query, sortingReplica);
+    const search = async (query: string, sortingReplica: SortingReplicas, filters?: string) => {
+        return await algoliaSearch.search(query, sortingReplica, filters);
     }
 
   return { findObject, updateObjectsPartially, search };

--- a/data/useSectionPopularArticles.ts
+++ b/data/useSectionPopularArticles.ts
@@ -19,7 +19,9 @@ export const useSectionPopularArticles: (section?: string) => Promise<{
     // get the last modified docs
     const objs = await searchAlgolia.search('', SortingReplicas.DocsByViewed);
     // take top 5
-    const topFive = objs.hits.slice(0, 5);
+    const topFive = !section 
+      ? objs.hits.slice(0, 5)
+      : objs.hits.filter((art: ArticleInput) => art.objectID?.includes(section + '|')).slice(0, 5);
     // convert to expected type
     const finalList: ArticleInput[] = [];
     for (let i = 0; i < topFive.length; i++) {

--- a/data/useSectionPopularArticles.ts
+++ b/data/useSectionPopularArticles.ts
@@ -17,11 +17,11 @@ export const useSectionPopularArticles: (section?: string) => Promise<{
   const refresh = async () => {
     pending.value = true;
     // get the last modified docs
-    const objs = await searchAlgolia.search('', SortingReplicas.DocsByViewed);
+    const objs = section 
+      ? await searchAlgolia.search('', SortingReplicas.DocsByViewed, `group:${section}`)
+      : await searchAlgolia.search('', SortingReplicas.DocsByViewed);
     // take top 5
-    const topFive = !section 
-      ? objs.hits.slice(0, 5)
-      : objs.hits.filter((art: ArticleInput) => art.objectID?.includes(section + '|')).slice(0, 5);
+    const topFive = objs.hits.slice(0, 5);
     // convert to expected type
     const finalList: ArticleInput[] = [];
     for (let i = 0; i < topFive.length; i++) {

--- a/domain/AlgoliaSearch.ts
+++ b/domain/AlgoliaSearch.ts
@@ -7,7 +7,8 @@ export enum SortingReplicas {
 };
 
 export default class AlgoliaSearch {
-    private requestOptions: { headers: { "x-algolia-application-id": string }, createIfNotExists?: boolean };
+    // note: you must set the the facet fields in the dashboard if you are to filter on them!!!
+    private requestOptions: { headers: { "x-algolia-application-id": string }, createIfNotExists?: boolean, filters?: string };
     private client: SearchClient;
     private index: SearchIndex
     private mainIndexName: string
@@ -40,13 +41,18 @@ export default class AlgoliaSearch {
     async updateObjectsPartially(objs: any[], createIfNotExists: boolean = true) {
         const requestOptions = { ...this.requestOptions };
         requestOptions.createIfNotExists = createIfNotExists;
-        return await this.index.partialUpdateObjects(objs, this.requestOptions);
+        return await this.index.partialUpdateObjects(objs, requestOptions);
     }
 
-    async search(query: string, sortingReplica: SortingReplicas) {
+    async search(query: string, sortingReplica: SortingReplicas, filters?: string) {
         this.resetIndexForSorting(sortingReplica);
 
-        return await this.index.search(query, this.requestOptions);
+        const requestOptions = { ...this.requestOptions };
+        if (filters) {
+            requestOptions.filters = filters;
+        }
+
+        return await this.index.search(query, requestOptions);
     }
 
     private resetIndexForSorting(replica: SortingReplicas) {

--- a/modules/algoliaIndexer.ts
+++ b/modules/algoliaIndexer.ts
@@ -49,6 +49,7 @@ export default defineNuxtModule({
                         parentSection: frontMatter.parentSection,
                         content: content.trim(),
                         modified: convertMsToUnixSeconds(fileStats.mtimeMs),
+                        group: frontMatter.objectID ? frontMatter.objectID.split('|')[0] : ""
                         // viewed: 0 // this field will be added from UI upon screen load
                     };
                     

--- a/pages/community.vue
+++ b/pages/community.vue
@@ -1,7 +1,11 @@
+<script lang="ts" setup>
+  const community = "community";
+</script>
+
 <template>
   <div>
     <SectionsHero />
     <SectionsCategories />
-    <SectionsPopularArticles />
+    <SectionsPopularArticles :root-section="community" />
   </div>
 </template>

--- a/pages/developers.vue
+++ b/pages/developers.vue
@@ -1,7 +1,11 @@
+<script lang="ts" setup>
+  const developers = "developers";
+</script>
+
 <template>
   <div>
     <SectionsHero />
     <SectionsCategories />
-    <SectionsPopularArticles />
+    <SectionsPopularArticles :root-section="developers" />
   </div>
 </template>

--- a/pages/validators.vue
+++ b/pages/validators.vue
@@ -1,7 +1,11 @@
+<script lang="ts" setup>
+  const validators = "validators";
+</script>
+
 <template>
   <div>
     <SectionsHero />
     <SectionsCategories />
-    <SectionsPopularArticles />
+    <SectionsPopularArticles :root-section="validators" />
   </div>
 </template>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,6 +34,7 @@ export type AlgoliaArticleIndex = {
   parentSection: string,
   content: string,
   modified: number, // Unix seconds
+  group: string, // should be set to root parent folder. e.g. community
   viewed?: number // this field is here only to document complete indexing object
 };
 


### PR DESCRIPTION
This item fixes issue with Most Popular list by section
- Algolia dashboard was used to add a new facet for a new index field called group. This field is representing the doc items root folder (section)
- Created new index field in module algoliaIndexer
- Updated search query so that when a section parameter is passed in it is used to filter the query
- Note please make sure this change does not impact the root Most Popular list which does not use section at all