### PR TITLE
Task/adev 53 work around global delayed ranking setting

### DIFF
--- a/components/Home/HighlightedArticles.vue
+++ b/components/Home/HighlightedArticles.vue
@@ -1,11 +1,27 @@
 <script lang="ts" setup>
   import { SortingReplicas } from '@/domain/AlgoliaSearch';
+  import { useHighlightedArticles } from '@/data/useHighlightedArticles';
+  import { Article } from '@/domain';
   import RecentArticles from './RecentArticles.vue';  
+  
+  const { search: searchPopular } = await useHighlightedArticles(SortingReplicas.DocsByViewed);
+  const { search: searchRecent } = await useHighlightedArticles(SortingReplicas.DocsByModified);
+  let popularArticles = ref<Article[]>([]);
+  let recentArticles = ref<Article[]>([]);
+
+  onMounted(async () => {
+    // when simulataneous calls are made they must be done sequentially
+    recentArticles.value = await searchRecent(SortingReplicas.DocsByModified);
+    console.log(SortingReplicas.DocsByModified, "search data", recentArticles.value);
+
+    popularArticles.value = await searchPopular(SortingReplicas.DocsByViewed);
+    console.log(SortingReplicas.DocsByViewed, "search data", popularArticles.value);
+  });
 </script>
 
 <template>
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-x-8 gap-y-12 border-b pb-16 mb-16 dark:border-gray-900 dark:border-opacity-20">
-    <RecentArticles />
-    <UiPopularArticles :sorting-replica="SortingReplicas.DocsByViewed" title="Popular articles" css-class="space-y-8" />
+    <RecentArticles :articles="recentArticles" />
+    <UiPopularArticles :articles="popularArticles" title="Popular articles" css-class="space-y-8" />
   </div>
 </template>

--- a/components/Home/RecentArticles.vue
+++ b/components/Home/RecentArticles.vue
@@ -1,24 +1,22 @@
 <script lang="ts" setup>
   import Articles from '@/components/Articles.vue';
-  import { useHighlightedArticles } from '@/data';
-  import { SortingReplicas } from '@/domain/AlgoliaSearch';
+  import { Article } from '@/domain';
+  import { PropType } from 'vue';
 
-  const { articles, refresh } = await useHighlightedArticles(SortingReplicas.DocsByModified);
+  const props = defineProps({
+    articles: { type: Array as PropType<Article[]>, required: false }
+  });
+
   const hasArticles = ref(false);
 
-  onMounted(async () => {
-    await refresh();
+  watch(() => props.articles, (newArticles) => {
+    hasArticles.value = newArticles?.length ? newArticles.length > 0 : false;
   });
-
-  watch(articles, (newArticles) => {
-    hasArticles.value = newArticles.length > 0;
-  });
-
 </script>
 
 <template>
   <div class="space-y-8" v-if="hasArticles">
     <h2 class="heading-3">Recent articles</h2>
-    <Articles :articles="articles" />
+    <Articles :articles="articles || []" />
   </div>
 </template>

--- a/components/Ui/PopularArticles.vue
+++ b/components/Ui/PopularArticles.vue
@@ -1,25 +1,24 @@
 <script lang="ts" setup>
   import Articles from '@/components/Articles.vue';
-  import { useHighlightedArticles } from '@/data';
-  import { SortingReplicas } from '@/domain/AlgoliaSearch';
   import { PropType } from 'vue';
+  import { Article } from '@/domain';
 
   const props = defineProps({
     title: { type: String, required: true },
-    cssClass: { type: String, required: true },    
-    rootSection: { type: String, required: false },
-    sortingReplica: { type: String as PropType<SortingReplicas>, required: true }
+    cssClass: { type: String, required: true },
+    articles: { type: Array as PropType<Article[]>, required: false }
   });
 
-  const { articles, refresh } = await useHighlightedArticles(props.sortingReplica, props.rootSection);
-  onMounted(async () => {
-    await refresh();
+  const hasArticles = ref(false);
+
+  watch(() => props.articles, (newArticles) => {
+    hasArticles.value = newArticles?.length ? newArticles.length > 0 : false;
   });
 </script>
 
 <template>
-  <div :class="props.cssClass">
+  <div :class="props.cssClass" v-if="hasArticles">
     <h2 class="heading-3">{{ props.title }}</h2>
-    <Articles :articles="articles" />
+    <Articles :articles="articles || []" />
   </div>
 </template>

--- a/data/useHighlightedArticles.ts
+++ b/data/useHighlightedArticles.ts
@@ -3,6 +3,8 @@ import { ArticleInput } from '@/types';
 import { Article } from '@/domain';
 import { useAlgoliaSearch } from '@/data/useAlgoliaSearch';
 import { SortingReplicas } from '@/domain/AlgoliaSearch';
+/// @ts-ignore
+import { v4 as uuidv4 } from 'uuid';
 
 export const useHighlightedArticles: (sortingReplica: SortingReplicas, section?: string) => Promise<{
   articles: ComputedRef<Article[]>;
@@ -10,7 +12,7 @@ export const useHighlightedArticles: (sortingReplica: SortingReplicas, section?:
   isLoading: ComputedRef<boolean>;
 }> = async (sortingReplica: SortingReplicas, section?: string) => {
   const searchAlgolia = await useAlgoliaSearch();
-  const asyncKey = section ? `most-popular-articles-${section}` : 'most-popular-articles';  
+  const asyncKey = section ? `highlighted-articles-${section}-${sortingReplica}` : `highlighted-articles-${sortingReplica}`;  
   const data = ref<ArticleInput[]>([]);
   const pending = ref(false);
 
@@ -26,7 +28,7 @@ export const useHighlightedArticles: (sortingReplica: SortingReplicas, section?:
     const finalList: ArticleInput[] = [];
     for (let i = 0; i < topFive.length; i++) {
       const item = topFive[i];
-      const { data: queryData } = await useAsyncData(asyncKey, () => queryContent().where({ objectID: item.objectID }).findOne());      
+      const { data: queryData } = await useAsyncData(`${asyncKey}-${uuidv4()}`, () => queryContent().where({ objectID: item.objectID }).findOne());      
       finalList.push({ 
         _id: queryData.value?._id, 
         title: queryData.value?.title, 

--- a/domain/AlgoliaSearch.ts
+++ b/domain/AlgoliaSearch.ts
@@ -3,7 +3,6 @@ import algoliasearch, { SearchClient, SearchIndex } from 'algoliasearch';
 // note: Algolia dashboard and index settings will use an environment prefix in the name
 // for example staging_docs_by_modified
 export enum SortingReplicas {
-    Main = 'Main',
     DocsByModified = 'docs_by_modified',
     DocsByViewed = 'docs_by_viewed'
 };
@@ -25,7 +24,8 @@ export default class AlgoliaSearch {
         
         this.index.setSettings({
             attributesForFaceting: [
-                'searchable(parentSection)'
+                'searchable(parentSection)',
+                'filterOnly(group)'
             ],
             replicas: [
                 env.toLocaleLowerCase() + "_" + SortingReplicas.DocsByModified,
@@ -61,7 +61,6 @@ export default class AlgoliaSearch {
     }
 
     private resetIndexForSorting(replica: SortingReplicas) {
-        this.index = this.client.initIndex(replica === SortingReplicas.Main ? this.mainIndexName : replica);
         if (replica === SortingReplicas.DocsByViewed) {
             this.index.setSettings({
                 ranking: [

--- a/pages/community.vue
+++ b/pages/community.vue
@@ -1,11 +1,20 @@
 <script lang="ts" setup>
   import { SortingReplicas } from '@/domain/AlgoliaSearch';
+  import { useHighlightedArticles } from '@/data/useHighlightedArticles';
+  import { Article } from '@/domain';
+
+  const { search } = await useHighlightedArticles(SortingReplicas.DocsByViewed);
+  let popularArticles = ref<Article[]>([]);
+
+  onMounted(async () => {
+    popularArticles.value = await search(SortingReplicas.DocsByViewed, "community");
+  });
 </script>
 
 <template>
   <div>
     <SectionsHero />
     <SectionsCategories />
-    <UiPopularArticles :sorting-replica="SortingReplicas.DocsByViewed" title="Most popular articles" css-class="grid grid-cols-1 pt-16 space-y-8 w-full" root-section="community" />
+    <UiPopularArticles :articles="popularArticles" title="Most popular articles" css-class="grid grid-cols-1 pt-16 space-y-8 w-full" />
   </div>
 </template>

--- a/pages/developers.vue
+++ b/pages/developers.vue
@@ -1,11 +1,20 @@
 <script lang="ts" setup>
   import { SortingReplicas } from '@/domain/AlgoliaSearch';
+  import { useHighlightedArticles } from '@/data/useHighlightedArticles';
+  import { Article } from '@/domain';
+
+  const { search } = await useHighlightedArticles(SortingReplicas.DocsByViewed);
+  let popularArticles = ref<Article[]>([]);
+
+  onMounted(async () => {
+    popularArticles.value = await search(SortingReplicas.DocsByViewed, "developers");
+  });
 </script>
 
 <template>
   <div>
     <SectionsHero />
     <SectionsCategories />
-    <UiPopularArticles :sorting-replica="SortingReplicas.DocsByViewed" title="Most popular articles" css-class="grid grid-cols-1 pt-16 space-y-8 w-full" root-section="developers" />
+    <UiPopularArticles :articles="popularArticles" title="Most popular articles" css-class="grid grid-cols-1 pt-16 space-y-8 w-full" />
   </div>
 </template>

--- a/pages/validators.vue
+++ b/pages/validators.vue
@@ -1,11 +1,20 @@
 <script lang="ts" setup>
   import { SortingReplicas } from '@/domain/AlgoliaSearch';
+  import { useHighlightedArticles } from '@/data/useHighlightedArticles';
+  import { Article } from '@/domain';
+
+  const { search } = await useHighlightedArticles(SortingReplicas.DocsByViewed);
+  let popularArticles = ref<Article[]>([]);
+
+  onMounted(async () => {
+    popularArticles.value = await search(SortingReplicas.DocsByViewed, "validators");
+  });
 </script>
 
 <template>
   <div>
     <SectionsHero />
     <SectionsCategories />
-    <UiPopularArticles :sorting-replica="SortingReplicas.DocsByViewed" title="Most popular articles" css-class="grid grid-cols-1 pt-16 space-y-8 w-full" root-section="validators" />
+    <UiPopularArticles :articles="popularArticles" title="Most popular articles" css-class="grid grid-cols-1 pt-16 space-y-8 w-full" />
   </div>
 </template>


### PR DESCRIPTION
Algolia search uses something called ranking and replicas in order to sort. Unfortunately ranking and replicas are global settings. This means for different desired sorting queries, the setting needs to be changed on each query. 

However the issue is, this setting is saved on their servers and has a lag (roughly 2 seconds give our take). Therefore if two or more queries run at same time and they each want a different sort, the query result will fail as they will all use the same sort (ranking).

The work around I have is to force the queries to run sequentially one after the other and to delay 2.5 seconds after each change of the ranking (it uses the index.setSettings call to change ranking). Simply awaiting each call does not work, because again the setting happens on their servers and has a lag to take effect. The delay I added works fairly consistently, although there have been a few times where it failed and did not sort as expected (usually only on the first screen refresh after a long pause).