### PR TITLE
remove rank switching replace by switching index

### DIFF
--- a/components/Home/HighlightedArticles.vue
+++ b/components/Home/HighlightedArticles.vue
@@ -11,10 +11,10 @@
 
   onMounted(async () => {
     // when simulataneous calls are made they must be done sequentially
-    recentArticles.value = await searchRecent(SortingReplicas.DocsByModified);
+    recentArticles.value = await searchRecent();
     console.log(SortingReplicas.DocsByModified, "search data", recentArticles.value);
 
-    popularArticles.value = await searchPopular(SortingReplicas.DocsByViewed);
+    popularArticles.value = await searchPopular();
     console.log(SortingReplicas.DocsByViewed, "search data", popularArticles.value);
   });
 </script>

--- a/data/useAlgoliaSearch.ts
+++ b/data/useAlgoliaSearch.ts
@@ -2,13 +2,13 @@ import { AlgoliaSearch } from '@/domain';
 import { useRuntimeConfig } from '#app';
 import { SortingReplicas } from '~~/domain/AlgoliaSearch';
 
-export const useAlgoliaSearch: () => Promise<{
+export const useAlgoliaSearch: (sortingReplica?: SortingReplicas) => Promise<{
   findObject: (searchPredicate: (hit: any) => boolean) => Promise<any>,
   updateObjectsPartially: (objs: any[], createIfNotExists?: boolean) => Promise<any>,
-  search: (query: string, sortingReplica: SortingReplicas, filters?: string) => Promise<any>
-}> = async () => {
+  search: (query: string, filters?: string) => Promise<any>
+}> = async (sortingReplica?: SortingReplicas) => {
     const runtimeConfig = useRuntimeConfig();
-    const algoliaSearch = new AlgoliaSearch(runtimeConfig.algolia.appId, runtimeConfig.algolia.writeApiKey, runtimeConfig.algolia.docIndex, runtimeConfig.algolia.env);
+    const algoliaSearch = new AlgoliaSearch(runtimeConfig.algolia.appId, runtimeConfig.algolia.writeApiKey, runtimeConfig.algolia.docIndex, runtimeConfig.algolia.env, sortingReplica);
 
     const findObject = async (searchPredicate: (hit: any) => boolean) => {
         return await algoliaSearch.findObject(searchPredicate);
@@ -18,8 +18,8 @@ export const useAlgoliaSearch: () => Promise<{
         return await algoliaSearch.updateObjectsPartially(objs, createIfNotExists);
     }
 
-    const search = async (query: string, sortingReplica: SortingReplicas, filters?: string) => {
-        return await algoliaSearch.search(query, sortingReplica, filters);
+    const search = async (query: string, filters?: string) => {
+        return await algoliaSearch.search(query, filters);
     }
 
   return { findObject, updateObjectsPartially, search };

--- a/data/useHighlightedArticles.ts
+++ b/data/useHighlightedArticles.ts
@@ -10,23 +10,23 @@ export const useHighlightedArticles: (sortingReplica: SortingReplicas, section?:
   articles: ComputedRef<Article[]>;
   refresh: () => Promise<void>;
   isLoading: ComputedRef<boolean>;
-  search: (searchSortingReplica: SortingReplicas, searchSection?: string) => Promise<Article[]>;
+  search: (searchSection?: string) => Promise<Article[]>;
 }> = async (sortingReplica: SortingReplicas, section?: string) => {
-  const searchAlgolia = await useAlgoliaSearch();
+  const searchAlgolia = await useAlgoliaSearch(sortingReplica);
   const asyncKey = section ? `highlighted-articles-${section}-${sortingReplica}` : `highlighted-articles-${sortingReplica}`;  
   const data = ref<Article[]>([]);
   const pending = ref(false);
 
   const refresh = async () => {
-    data.value = await search(sortingReplica, section);
+    data.value = await search(section);
   }
 
-  const search = async (searchSortingReplica: SortingReplicas, searchSection?: string) => {
+  const search = async (searchSection?: string) => {
     pending.value = true;
     // get the last modified docs
     const objs = searchSection 
-      ? await searchAlgolia.search('', searchSortingReplica, `group:${searchSection}`)
-      : await searchAlgolia.search('', searchSortingReplica);
+      ? await searchAlgolia.search('', `group:${searchSection}`)
+      : await searchAlgolia.search('');
     // take top 5
     const topFive = objs.hits.slice(0, 5);
     // convert to expected type

--- a/pages/community.vue
+++ b/pages/community.vue
@@ -7,7 +7,7 @@
   let popularArticles = ref<Article[]>([]);
 
   onMounted(async () => {
-    popularArticles.value = await search(SortingReplicas.DocsByViewed, "community");
+    popularArticles.value = await search("community");
   });
 </script>
 

--- a/pages/developers.vue
+++ b/pages/developers.vue
@@ -7,7 +7,7 @@
   let popularArticles = ref<Article[]>([]);
 
   onMounted(async () => {
-    popularArticles.value = await search(SortingReplicas.DocsByViewed, "developers");
+    popularArticles.value = await search("developers");
   });
 </script>
 

--- a/pages/validators.vue
+++ b/pages/validators.vue
@@ -7,7 +7,7 @@
   let popularArticles = ref<Article[]>([]);
 
   onMounted(async () => {
-    popularArticles.value = await search(SortingReplicas.DocsByViewed, "validators");
+    popularArticles.value = await search("validators");
   });
 </script>
 


### PR DESCRIPTION
Switched from using ranking resets to just using the replica as index when required (otherwise uses standard index).