### PR TITLE
Addition of the IBC Channels page

### DIFF
--- a/content/5.resources/2.ibc-channels.md
+++ b/content/5.resources/2.ibc-channels.md
@@ -1,0 +1,22 @@
+---
+objectID: resources|ibc-channels
+title: IBC Channels
+description: This page serves as a reference for anyone looking to explore the various IBC channels that connect the Archway network to other networks.
+parentSection: Resources
+parentSectionPath: /resources
+---
+
+# IBC Channels
+
+Here, you can find a comprehensive list of channels that connect the Archway blockchain network with other IBC-enabled networks.
+
+## Constantine (Testnet)
+
+The chain ID for the Constantine testnet is `constantine-1`.
+
+| **Source Channel** | **Destination** | **Destination Chain ID**     | **Destination Channel** |
+| :----------------- |:----------------|------------------------------|-------------------------|
+| channel-0          | Osmosis         | osmo-test-4                  | channel-2156            |
+| channel-1          | Axelar          | axelar-testnet-lisbon-3      | channel-159             |
+
+You can also find the list of IBC channels in our github <a href="https://github.com/archway-network/networks/tree/main/_IBC" target="_blank" >networks</a> repo.


### PR DESCRIPTION
Developers are requesting access to the list of active IBC channels within the Archway network. Due to the ongoing hackathon, we should expedite this addition to the production environment. This will not only make it easier for developers to access the information but also enable the support team to efficiently direct developers to the appropriate resource.