### PR TITLE
Addition of Airdrop Snapshot page

### DIFF
--- a/content/3.community/6.airdrop-snapshots.md
+++ b/content/3.community/6.airdrop-snapshots.md
@@ -1,0 +1,43 @@
+---
+objectID: community|airdrop-snapshots
+parentSection: Participate
+parentSectionPath: /community
+title: Airdrop snapshots
+description: An explanation of all the snapshots used to generate the Archway airdrop.
+---
+
+# Airdrop snapshots
+
+The Genesis Airdrop, initiated by the Archway Foundation, serves as a means of giving back to active Cosmonauts while helping to distribute the ARCH token supply more widely. Contained within this [folder](https://drive.google.com/drive/folders/1WOORbluqi_DrGTrLzPVHhyk27OYNR97U) are three selectively trimmed snapshots, each created within the timeframe from the genesis of their respective chains until 1/16/2023 at 18:03 UTC, following the [phi - golden ratio](https://en.wikipedia.org/wiki/Golden_ratio) principle. The ultimate compilation of addresses can be accessed through this link [Final list of addresses](https://docs.google.com/spreadsheets/d/1rzMuhKDJ1ur0F_jXtT5ZLp-d3tcQuNxV-dhCU8rQbgQ/edit?usp=sharing).
+
+
+## Cosmos stakedrop
+
+The snapshot for the Cosmos airdrop targets stakers within the Cosmos ecosystem. Eligibility requires a stake of **25 or more** ATOM. However, tokens that were delegated to the validators listed below were not considered:
+
+- Two validators from Coinbase
+- Two validators from Binance
+- One validator from Kraken
+
+A total of **141,614 addresses** from the snapshot will participate in the airdrop, with **29,412,980 ARCH** tokens to be distributed among these addresses. The allocation is 1:1 for staked ATOM between 25 and 2000, averaging about **207.7 ARCH** per wallet.
+
+## Axelar bridgedrop
+
+Axelar Bridgedrop employs a unique airdrop mechanism. The snapshot for the Bridgedrop captures the state of all the assets bridged between different blockchain networks using Axelar's cross-chain communication protocol.
+
+To be eligible for this airdrop, a minimum of **$5,000** must be bridged to Cosmos in one transaction. A total of **7,250 addresses** will participate in the airdrop, with a collective distribution of **2,900,000 ARCH** tokens. Each participating address will receive an equal allocation of **400 ARCH** tokens.
+
+
+## Terra classic dev drop
+
+Terra Classic Dev Drop focuses on rewarding developers who have contributed to the Terra ecosystem. To be eligible for this distribution, you must have deployed a contract on Terra Classic. A total of **6,416 addresses** have met this criterion, making them eligible for a share of the **2,566,400 ARCH** tokens set aside for the airdrop. Each of these addresses will receive a uniform allotment of **400 ARCH** tokens.
+
+
+## Testnet Dev Drop
+
+Similar to the Terra Classic Dev Drop, the Testnet Dev Drop focuses on incentivizing developers to contribute to the testnet ecosystem. In order to be eligible, your address must have been used on either the **constantine-2** or **Torii** testnets in the past. Each qualifying address will receive a distribution of **25 ARCH** tokens. With a total of **36,061** eligible addresses, this amounts to a distribution of **901,525 ARCH** tokens.
+
+
+## Conclusion
+
+A total of **191,342 addresses** qualify for the airdrop, which will distribute **35,753,330 ARCH** tokens. This leaves a balance of **14,246,670 ARCH** tokens available for future airdrops.

--- a/content/3.community/6.airdrop-snapshots.md
+++ b/content/3.community/6.airdrop-snapshots.md
@@ -6,12 +6,12 @@ title: Airdrop snapshots
 description: An explanation of all the snapshots used to generate the first Archway airdrop.
 ---
 
-# Airdrop Snapshots
+# Airdrop snapshots
 
 The Genesis Airdrop, initiated by the Archway Foundation, serves as a means of giving back to active Cosmonauts while helping to distribute the ARCH token supply more widely. Snapshots were taken for selective chains, each capturing the timeframe from the genesis of their respective chains until 1/16/2023 at 18:03 UTC, following the [phi - golden ratio](https://en.wikipedia.org/wiki/Golden_ratio) principle. The ultimate compilation of addresses can be accessed through this link [Final list of addresses](https://docs.google.com/spreadsheets/d/1rzMuhKDJ1ur0F_jXtT5ZLp-d3tcQuNxV-dhCU8rQbgQ/edit?usp=sharing).
 
 
-## Cosmos StakeDrop
+## Cosmos stakeDrop
 
 The snapshot for the Cosmos airdrop targets stakers within the Cosmos ecosystem. Eligibility requires a stake of **25 or more** ATOM. However, tokens that were delegated to the validators listed below were not considered:
 
@@ -21,19 +21,19 @@ The snapshot for the Cosmos airdrop targets stakers within the Cosmos ecosystem.
 
 A total of **141,614 addresses** from the snapshot will participate in the airdrop, with **29,412,980 ARCH** tokens to be distributed among these addresses. The allocation is 1:1 for staked ATOM between 25 and 2000, averaging about **207.7 ARCH** per wallet.
 
-## Axelar BridgeDrop
+## Axelar bridgeDrop
 
 Axelar Bridgedrop employs a unique airdrop mechanism. The snapshot for the Bridgedrop captures the state of all the assets bridged between different blockchain networks using Axelar's cross-chain communication protocol.
 
 To be eligible for this airdrop, a minimum of **€5,000** must have been bridged via Axelar. A total of **7,250 addresses** were captured in this snapshot for the airdrop, with a collective distribution of **2,900,000 ARCH** tokens. Each participating address will receive an equal allocation of **400 ARCH** tokens.
 
 
-## Terra (Classic) DevDrop
+## Terra (classic) devDrop
 
 Terra Classic Dev Drop focuses on rewarding developers who have contributed to the Terra ecosystem. To be eligible for this distribution, you must have deployed a contract on Terra Classic. A total of **6,416 addresses** have met this criterion, making them eligible for a share of the **2,566,400 ARCH** tokens set aside for the airdrop. Each of these addresses will receive a uniform allotment of **400 ARCH** tokens.
 
 
-## Testnet DevDrop
+## Testnet devDrop
 
 Similar to the Terra Classic Dev Drop, the Testnet Dev Drop focuses on rewarding developers who contributed to the Archway testnet ecosystem. In order to be eligible, your address must have been used on either the **constantine-2** or **Torii** testnets in the past. Due to the nature of this being a testnet, some state history has been lost over time so some addresses may not be present but everything that could be recovered is present. Each qualifying address will receive a distribution of **25 ARCH** tokens. With a total of **36,061** eligible addresses, this amounts to a distribution of **901,525 ARCH** tokens.
 

--- a/content/3.community/6.airdrop-snapshots.md
+++ b/content/3.community/6.airdrop-snapshots.md
@@ -3,15 +3,15 @@ objectID: community|airdrop-snapshots
 parentSection: Participate
 parentSectionPath: /community
 title: Airdrop snapshots
-description: An explanation of all the snapshots used to generate the Archway airdrop.
+description: An explanation of all the snapshots used to generate the first Archway airdrop.
 ---
 
-# Airdrop snapshots
+# Airdrop Snapshots
 
-The Genesis Airdrop, initiated by the Archway Foundation, serves as a means of giving back to active Cosmonauts while helping to distribute the ARCH token supply more widely. Contained within this [folder](https://drive.google.com/drive/folders/1WOORbluqi_DrGTrLzPVHhyk27OYNR97U) are three selectively trimmed snapshots, each created within the timeframe from the genesis of their respective chains until 1/16/2023 at 18:03 UTC, following the [phi - golden ratio](https://en.wikipedia.org/wiki/Golden_ratio) principle. The ultimate compilation of addresses can be accessed through this link [Final list of addresses](https://docs.google.com/spreadsheets/d/1rzMuhKDJ1ur0F_jXtT5ZLp-d3tcQuNxV-dhCU8rQbgQ/edit?usp=sharing).
+The Genesis Airdrop, initiated by the Archway Foundation, serves as a means of giving back to active Cosmonauts while helping to distribute the ARCH token supply more widely. Snapshots were taken for selective chains, each capturing the timeframe from the genesis of their respective chains until 1/16/2023 at 18:03 UTC, following the [phi - golden ratio](https://en.wikipedia.org/wiki/Golden_ratio) principle. The ultimate compilation of addresses can be accessed through this link [Final list of addresses](https://docs.google.com/spreadsheets/d/1rzMuhKDJ1ur0F_jXtT5ZLp-d3tcQuNxV-dhCU8rQbgQ/edit?usp=sharing).
 
 
-## Cosmos stakedrop
+## Cosmos Stakedrop
 
 The snapshot for the Cosmos airdrop targets stakers within the Cosmos ecosystem. Eligibility requires a stake of **25 or more** ATOM. However, tokens that were delegated to the validators listed below were not considered:
 
@@ -25,19 +25,21 @@ A total of **141,614 addresses** from the snapshot will participate in the airdr
 
 Axelar Bridgedrop employs a unique airdrop mechanism. The snapshot for the Bridgedrop captures the state of all the assets bridged between different blockchain networks using Axelar's cross-chain communication protocol.
 
-To be eligible for this airdrop, a minimum of **$5,000** must be bridged to Cosmos in one transaction. A total of **7,250 addresses** will participate in the airdrop, with a collective distribution of **2,900,000 ARCH** tokens. Each participating address will receive an equal allocation of **400 ARCH** tokens.
+To be eligible for this airdrop, a minimum of **€5,000** must have been bridged via Axelar. A total of **7,250 addresses** were captured in this snapshot for the airdrop, with a collective distribution of **2,900,000 ARCH** tokens. Each participating address will receive an equal allocation of **400 ARCH** tokens.
 
 
-## Terra classic dev drop
+## Terra (Classic) Dev Drop
 
 Terra Classic Dev Drop focuses on rewarding developers who have contributed to the Terra ecosystem. To be eligible for this distribution, you must have deployed a contract on Terra Classic. A total of **6,416 addresses** have met this criterion, making them eligible for a share of the **2,566,400 ARCH** tokens set aside for the airdrop. Each of these addresses will receive a uniform allotment of **400 ARCH** tokens.
 
 
 ## Testnet Dev Drop
 
-Similar to the Terra Classic Dev Drop, the Testnet Dev Drop focuses on incentivizing developers to contribute to the testnet ecosystem. In order to be eligible, your address must have been used on either the **constantine-2** or **Torii** testnets in the past. Each qualifying address will receive a distribution of **25 ARCH** tokens. With a total of **36,061** eligible addresses, this amounts to a distribution of **901,525 ARCH** tokens.
+Similar to the Terra Classic Dev Drop, the Testnet Dev Drop focuses on rewarding developers who contributed to the Archway testnet ecosystem. In order to be eligible, your address must have been used on either the **constantine-2** or **Torii** testnets in the past. Due to the nature of this being a testnet, some state history has been lost over time so some addresses may not be present but everything that could be recovered is present. Each qualifying address will receive a distribution of **25 ARCH** tokens. With a total of **36,061** eligible addresses, this amounts to a distribution of **901,525 ARCH** tokens.
 
 
 ## Conclusion
+
+The airdrop will be claimable shortly after Archway mainnet genesis to all active participants via  Archway Connect. Check if your address is present in the snapshots now via our Address Eligibility Checker tool.
 
 A total of **191,342 addresses** qualify for the airdrop, which will distribute **35,753,330 ARCH** tokens. This leaves a balance of **14,246,670 ARCH** tokens available for future airdrops.

--- a/content/3.community/6.airdrop-snapshots.md
+++ b/content/3.community/6.airdrop-snapshots.md
@@ -13,7 +13,7 @@ The Genesis Airdrop, initiated by the Archway Foundation, serves as a means of g
 
 ## Cosmos stakeDrop
 
-The snapshot for the Cosmos airdrop targets stakers within the Cosmos ecosystem. Eligibility requires a stake of **25 or more** ATOM. However, tokens that were delegated to the validators listed below were not considered:
+The snapshot for the Cosmos airdrop targets stakers within the Cosmos ecosystem. Eligibility required a stake of **25 or more** ATOM. However, tokens that were delegated to the validators listed below were not considered in the interest of promoting decentralisation:
 
 - Two validators from Coinbase
 - Two validators from Binance

--- a/content/3.community/6.airdrop-snapshots.md
+++ b/content/3.community/6.airdrop-snapshots.md
@@ -11,7 +11,7 @@ description: An explanation of all the snapshots used to generate the first Arch
 The Genesis Airdrop, initiated by the Archway Foundation, serves as a means of giving back to active Cosmonauts while helping to distribute the ARCH token supply more widely. Snapshots were taken for selective chains, each capturing the timeframe from the genesis of their respective chains until 1/16/2023 at 18:03 UTC, following the [phi - golden ratio](https://en.wikipedia.org/wiki/Golden_ratio) principle. The ultimate compilation of addresses can be accessed through this link [Final list of addresses](https://docs.google.com/spreadsheets/d/1rzMuhKDJ1ur0F_jXtT5ZLp-d3tcQuNxV-dhCU8rQbgQ/edit?usp=sharing).
 
 
-## Cosmos Stakedrop
+## Cosmos StakeDrop
 
 The snapshot for the Cosmos airdrop targets stakers within the Cosmos ecosystem. Eligibility requires a stake of **25 or more** ATOM. However, tokens that were delegated to the validators listed below were not considered:
 
@@ -21,19 +21,19 @@ The snapshot for the Cosmos airdrop targets stakers within the Cosmos ecosystem.
 
 A total of **141,614 addresses** from the snapshot will participate in the airdrop, with **29,412,980 ARCH** tokens to be distributed among these addresses. The allocation is 1:1 for staked ATOM between 25 and 2000, averaging about **207.7 ARCH** per wallet.
 
-## Axelar bridgedrop
+## Axelar BridgeDrop
 
 Axelar Bridgedrop employs a unique airdrop mechanism. The snapshot for the Bridgedrop captures the state of all the assets bridged between different blockchain networks using Axelar's cross-chain communication protocol.
 
 To be eligible for this airdrop, a minimum of **€5,000** must have been bridged via Axelar. A total of **7,250 addresses** were captured in this snapshot for the airdrop, with a collective distribution of **2,900,000 ARCH** tokens. Each participating address will receive an equal allocation of **400 ARCH** tokens.
 
 
-## Terra (Classic) Dev Drop
+## Terra (Classic) DevDrop
 
 Terra Classic Dev Drop focuses on rewarding developers who have contributed to the Terra ecosystem. To be eligible for this distribution, you must have deployed a contract on Terra Classic. A total of **6,416 addresses** have met this criterion, making them eligible for a share of the **2,566,400 ARCH** tokens set aside for the airdrop. Each of these addresses will receive a uniform allotment of **400 ARCH** tokens.
 
 
-## Testnet Dev Drop
+## Testnet DevDrop
 
 Similar to the Terra Classic Dev Drop, the Testnet Dev Drop focuses on rewarding developers who contributed to the Archway testnet ecosystem. In order to be eligible, your address must have been used on either the **constantine-2** or **Torii** testnets in the past. Due to the nature of this being a testnet, some state history has been lost over time so some addresses may not be present but everything that could be recovered is present. Each qualifying address will receive a distribution of **25 ARCH** tokens. With a total of **36,061** eligible addresses, this amounts to a distribution of **901,525 ARCH** tokens.
 


### PR DESCRIPTION
This page gives details on all the snapshots used to generate the first Archway airdrop.