### PR TITLE
Update self delegation amount in create validator command for mainnet launch

### DIFF
--- a/content/4.validators/2.becoming-a-validator/3.running-a-validator-node.md
+++ b/content/4.validators/2.becoming-a-validator/3.running-a-validator-node.md
@@ -89,7 +89,7 @@ Binary
 ::highlight-card
 
 ```bash
-  archwayd gentx my-validator-account 10000000000000000000aarch --commission-rate 0.01 --commission-max-rate 0.1 --commission-max-change-rate 0.1  --pubkey "$(archwayd tendermint show-validator)" --chain-id archway-1 --fees 180000000000000000aarch
+  archwayd gentx my-validator-account 9500000000000000000aarch --commission-rate 0.01 --commission-max-rate 0.1 --commission-max-change-rate 0.1  --pubkey "$(archwayd tendermint show-validator)" --chain-id archway-1 --fees 180000000000000000aarch
 ```
 ::
 
@@ -100,7 +100,7 @@ Docker
 ::highlight-card
 
 ```bash
-docker run --rm -it -v ~/.archway:/root/.archway archwaynetwork/archwayd:archway-1 gentx my-validator-account 10000000000000000000aarch --commission-rate 0.01 --commission-max-rate 0.1 --commission-max-change-rate 0.1 --pubkey "$(archwayd tendermint show-validator)" --chain-id archway-1 --fees 180000000000000000aarch
+docker run --rm -it -v ~/.archway:/root/.archway archwaynetwork/archwayd:archway-1 gentx my-validator-account 9500000000000000000aarch --commission-rate 0.01 --commission-max-rate 0.1 --commission-max-change-rate 0.1 --pubkey "$(archwayd tendermint show-validator)" --chain-id archway-1 --fees 180000000000000000aarch
 ```
 ::
 


### PR DESCRIPTION
Self delegations must be less than 9.82Arch to allow for 0.18Arch to be paid as gas for mainnet.