### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/data/useContentSearch.ts
+++ b/data/useContentSearch.ts
@@ -1,7 +1,7 @@
 import { Ref } from 'vue';
 import { useQuery } from '@tanstack/vue-query';
 import MeiliSearch from 'meilisearch';
-import { useRuntimeConfig } from '#app';
+import { useRuntimeConfig } from '#imports';
 
 import { ContentMetadata } from '@/domain';
 

--- a/plugins/vue-query.ts
+++ b/plugins/vue-query.ts
@@ -1,6 +1,6 @@
 import type { DehydratedState, VueQueryPluginOptions } from '@tanstack/vue-query';
 import { VueQueryPlugin, QueryClient, hydrate, dehydrate } from '@tanstack/vue-query';
-import { useState } from '#app';
+import { useState } from '#imports';
 
 export default defineNuxtPlugin(nuxt => {
   const vueQueryState = useState<DehydratedState | null>('vue-query');


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.