### PR TITLE
Add Chainroot as community explorer and snapshot

### DIFF
--- a/content/4.validators/1.running-a-node/5.join-a-network/4.sync-from-snapshot.md
+++ b/content/4.validators/1.running-a-node/5.join-a-network/4.sync-from-snapshot.md
@@ -50,6 +50,8 @@ Also, you can use the snapshot maintained by the community. Please make sure to 
 
 - <a href="https://services.kjnodes.com/home/testnet/archway/snapshot" target="_blank">kjnodes.com</a>
 
+- <a href="https://kb.chainroot.dev/networks/archway/downloads" target="_blank">kb.chainroot.io</a>
+
 ::alert{variant="info"}
 -->
 

--- a/content/5.resources/3.blockexplorers.md
+++ b/content/5.resources/3.blockexplorers.md
@@ -25,6 +25,7 @@ Here are some of the available block explorers for Archway's mainnet, Triomphe:
 - <a href="https://explorer.silknodes.io/archway" target="_blank">Silk Nodes</a>
 - <a href="https://ping.pub/archway" target="_blank">Ping.Pub</a>
 - <a href="https://ezstaking.app/archway" target="_blank">EZ Staking</a>
+- <a href="https://explorer.chainroot.io/archway" target="_blank">Chainroot</a>
 
 
 ## Testnet


### PR DESCRIPTION
We look forward to this PR being accepted to help the Archway community. Also, checking the snapshot endpoints of kjnodes.com and Autostake returns 404.